### PR TITLE
Container reservations and location type restrictions

### DIFF
--- a/app/controllers/api/locations_controller.rb
+++ b/app/controllers/api/locations_controller.rb
@@ -1,7 +1,7 @@
 class Api::LocationsController < ApiController
 
   def index
-    render json: Location.by_building
+    render json: Location.by_root
   end
 
   def show

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -2,7 +2,7 @@ class LocationsController < ApplicationController
 
   before_action :locations, only: [:index]
   before_action :set_location, except: [:index, :activate, :deactivate]
-  
+
   def index
   end
 
@@ -47,7 +47,7 @@ class LocationsController < ApplicationController
 protected
 
   def locations
-    @locations = Location.by_building
+    @locations = Location.by_root
   end
 
   helper_method :locations

--- a/app/form_object/form_object.rb
+++ b/app/form_object/form_object.rb
@@ -70,7 +70,7 @@ module FormObject
 
     class_attribute :form_variables
     self.form_variables = FormObject::FormVariables.new(self, _model.underscore.to_sym, [:controller, :action])
-  
+
     validate :check_for_errors
 
     define_singleton_method :model_name do

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -30,11 +30,7 @@ private
   end
 
   def set_team
-    @model.team_id = if reserve_param?
-        current_user.team_id
-      else
-        nil
-      end
+    @model.team_id = reserve_param? ? current_user.team_id : nil
   end
 
   def only_same_team_can_release_location

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -11,7 +11,7 @@ class LocationForm
 
   after_assigning_model_variables :transform_location, :set_team
 
-  delegate :parent, :barcode, :parentage, :type, :coordinateable?, :reserved?, to: :location
+  delegate :parent, :barcode, :parentage, :type, :coordinateable?, :reserved?, :reserved_by, to: :location
 
   attr_writer :coordinateable, :reserve
 

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -34,11 +34,7 @@ private
   end
 
   def only_same_team_can_release_location
-    if @model.team_id_changed? && !reserve_param?
-      unless @model.team_id_was === current_user.team_id
-        errors.add(:base, I18n.t("errors.messages.location_release", team: @model.reload.team.name))
-      end
-    end
+    LocationReleaseValidator.new(team_id: current_user.team_id).validate(self) if !reserve_param?
   end
 
   def reserve_param?

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -4,23 +4,49 @@ class LocationForm
 
   include AuthenticationForm
   include Auditor
-  
+
+  validate :only_same_team_can_release_location
+
   set_attributes :name, :location_type_id, :parent_id, :container, :status, :rows, :columns
 
-  after_assigning_model_variables :transform_location
+  after_assigning_model_variables :transform_location, :set_team
 
-  delegate :parent, :barcode, :parentage, :type, :coordinateable?, to: :location
+  delegate :parent, :barcode, :parentage, :type, :coordinateable?, :reserved?, to: :location
 
-  attr_writer :coordinateable
+  attr_writer :coordinateable, :reserve
 
   def coordinateable
     @coordinateable ||= coordinateable?
+  end
+
+  def reserve
+    @reserve ||= reserved?
   end
 
 private
 
   def transform_location
     @model = location.transform if location.new_record?
+  end
+
+  def set_team
+    @model.team_id = if reserve_param?
+        current_user.team_id
+      else
+        nil
+      end
+  end
+
+  def only_same_team_can_release_location
+    if @model.team_id_changed? && !reserve_param?
+      unless @model.team_id_was === current_user.team_id
+        errors.add(:base, I18n.t("errors.messages.location_release", team: @model.reload.team.name))
+      end
+    end
+  end
+
+  def reserve_param?
+    params.fetch(:location).fetch(:reserve, "0") == "1"
   end
 
 end

--- a/app/forms/scan_form.rb
+++ b/app/forms/scan_form.rb
@@ -8,12 +8,12 @@ class ScanForm
 
   set_form_variables :labwares, :labware_barcodes, :location_barcode, location: :find_location
 
-  after_validate do 
-    scan.add_attributes_from_collection(LabwareCollection.new(location, current_user, labwares || labware_barcodes).push)
+  after_validate do
+    scan.add_attributes_from_collection(LabwareCollection.new(location, current_user, _labwares).push)
     scan.save
   end
 
-  validate :check_location
+  validate :check_location, :check_reservation
 
   delegate :message, :created_at, :updated_at, to: :scan
 
@@ -25,6 +25,29 @@ private
 
   def check_location
     LocationValidator.new.validate(self)
+  end
+
+  def check_reservation
+    barcodes = _labwares.instance_of?(String) ? _labwares.split("\n") : _labwares
+
+    barcodes.each do |barcode|
+      labware = Labware.find_or_initialize_by_barcode(barcode)
+      next if labware.location.empty?
+      check_location_for_reservation(labware.location)
+    end
+  end
+
+  # Check through all ancestors to make sure none are reserved
+  def check_location_for_reservation(location)
+    if location.reserved? && location.reserved_by != current_user.team
+      errors.add(:location, I18n.t("errors.messages.reserved", team: location.reserved_by.name))
+      return
+    end
+    check_location_for_reservation(location.parent) if location.parent_id?
+  end
+
+  def _labwares
+    labwares || labware_barcodes
   end
 
 end

--- a/app/models/concerns/reservable.rb
+++ b/app/models/concerns/reservable.rb
@@ -1,0 +1,23 @@
+module Reservable
+
+  extend ActiveSupport::Concern
+
+  def reserved?
+    team.present?
+  end
+
+  # Has to be released before it can be reserved
+  def reserve(new_team)
+    return false if team.present?
+    update_attribute(:team, new_team)
+  end
+
+  def reserved_by
+    team
+  end
+
+  def release
+    update_attribute(:team, nil)
+  end
+
+end

--- a/app/models/labware_collection.rb
+++ b/app/models/labware_collection.rb
@@ -54,5 +54,5 @@ private
       location.coordinates.find_by_position(labware.permit(:position, :row, :column))
     end
   end
-  
+
 end

--- a/app/models/location_type.rb
+++ b/app/models/location_type.rb
@@ -6,6 +6,7 @@ class LocationType < ActiveRecord::Base
   include Auditable
 
   has_many :locations
+  has_many :restrictions, dependent: :destroy
 
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
@@ -14,33 +15,6 @@ class LocationType < ActiveRecord::Base
   searchable_by :name
 
   before_destroy :check_locations
-
-  #TODO: Buildings and Sites need to be dealt with differently to ensure more flexible code
-  def self.building
-    find_by_name("Building")
-  end
-
-  def self.building?(location_type)
-    location_type == building
-  end
-
-  def self.not_building?(location_type)
-    location_type != building
-  end
-
-   def self.site
-    find_by_name("Site")
-  end
-
-  def self.site?(location_type)
-    location_type == site
-  end
-
-  def self.not_site?(location_type)
-    location_type != site
-  end
-
-
 
   ##
   # A location type can only be destroyed if it has no locations

--- a/app/models/location_types_restriction.rb
+++ b/app/models/location_types_restriction.rb
@@ -1,0 +1,6 @@
+class LocationTypesRestriction < ActiveRecord::Base
+
+  belongs_to :location_type
+  belongs_to :parentage_restriction
+
+end

--- a/app/models/locations/location.rb
+++ b/app/models/locations/location.rb
@@ -25,9 +25,7 @@ class Location < ActiveRecord::Base
     validates_format_of :name, without: /UNKNOWN/i
   end
 
-  validates_with ParentLocationValidator
-
-  validate :only_containers_can_be_reserved
+  validates_with ContainerReservationValidator
 
   scope :without, ->(location) { active.where.not(id: location.id).order(id: :desc) }
   scope :without_unknown, -> { where.not(name: UNKNOWN) }
@@ -142,12 +140,6 @@ class Location < ActiveRecord::Base
   # The barcode is the name downcased with spaces replaced by dashes with the id added again separated by a space.
   def generate_barcode
     update_column(:barcode, "lw-#{self.name.gsub(' ', '-').downcase}-#{self.id}")
-  end
-
-  def only_containers_can_be_reserved
-    if team.present? && !container?
-      errors.add(:base, 'Only Locations which are containers can be reserved')
-    end
   end
 
 end

--- a/app/models/locations/location.rb
+++ b/app/models/locations/location.rb
@@ -23,13 +23,17 @@ class Location < ActiveRecord::Base
   with_options unless: :unknown? do
     validates :location_type, existence: true
     validates_format_of :name, without: /UNKNOWN/i
+
+    before_validation do
+      apply_restrictions
+    end
   end
 
   validates_with ContainerReservationValidator
 
   scope :without, ->(location) { active.where.not(id: location.id).order(id: :desc) }
   scope :without_unknown, -> { where.not(name: UNKNOWN) }
-  scope :by_building, -> { without_unknown.where(location_type_id: LocationType.building) }
+  scope :by_root, -> { without_unknown.where(parent_id: nil) }
 
   before_save :set_parentage
   after_create :generate_barcode
@@ -140,6 +144,13 @@ class Location < ActiveRecord::Base
   # The barcode is the name downcased with spaces replaced by dashes with the id added again separated by a space.
   def generate_barcode
     update_column(:barcode, "lw-#{self.name.gsub(' ', '-').downcase}-#{self.id}")
+  end
+
+  def apply_restrictions
+    return unless location_type
+    location_type.restrictions.each do |restriction|
+      validates_with restriction.validator, restriction.params
+    end
   end
 
 end

--- a/app/models/restrictions/parentage_restriction.rb
+++ b/app/models/restrictions/parentage_restriction.rb
@@ -1,0 +1,11 @@
+## A special kind of restriction that requires a relationship with location_types
+class ParentageRestriction < Restriction
+
+  has_many :location_types_restrictions, foreign_key: "restriction_id", dependent: :destroy
+  has_many :location_types, through: :location_types_restrictions
+
+  def params
+    super.merge(location_types: location_types)
+  end
+
+end

--- a/app/models/restrictions/parentage_restriction.rb
+++ b/app/models/restrictions/parentage_restriction.rb
@@ -1,7 +1,7 @@
 ## A special kind of restriction that requires a relationship with location_types
 class ParentageRestriction < Restriction
 
-  has_many :location_types_restrictions, foreign_key: "restriction_id", dependent: :destroy
+  has_many :location_types_restrictions, foreign_key: "restriction_id", dependent: :delete_all
   has_many :location_types, through: :location_types_restrictions
 
   def params

--- a/app/models/restrictions/restriction.rb
+++ b/app/models/restrictions/restriction.rb
@@ -1,0 +1,25 @@
+## A restriction can be created with a validator and optional parameters
+#  A restriction can be added to a LocationType
+#  When a Location of that LocationType is created, each of the restrictions' validators are
+#  passed to the Location through validates_with, along with the params
+
+# restriction = Restriction.new(validator: MyValidator, params: { starts_with: "X" })
+# location_type.restrictions << restriction
+# Location.create(name: "Fridge", location_type: location_type)
+
+# MyValidator is run
+class Restriction < ActiveRecord::Base
+
+  belongs_to :location_type
+  serialize :params
+  validates :validator, presence: true
+
+  def params
+    super || {}
+  end
+
+  def validator
+    super.constantize if validator?
+  end
+
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -7,10 +7,12 @@ class Team < ActiveRecord::Base
   validates :number, presence: true, uniqueness: true, numericality: true
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
+  has_many :locations
+
   ##
   # Needed for the audit record.
   def as_json(options = {})
     super(options).merge(uk_dates)
   end
-  
+
 end

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -24,6 +24,11 @@
       </li>
       <div class="container-options" data-behavior="container">
         <li>
+          <%= f.check_box :reserve %>
+          <%= f.label :reserve, "Reserve?" %>
+          <span class="note">(Only your team can store labware in this container)</span>
+        </li>
+        <li>
           <%= f.check_box :coordinateable, data: {toggle: "coordinates"} %>
           <%= f.label :coordinateable, "Has Co-ordinates" %>
         </li>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -26,7 +26,13 @@
         <li>
           <%= f.check_box :reserve %>
           <%= f.label :reserve, "Reserve?" %>
-          <span class="note">(Only your team can store labware in this container)</span>
+          <span class="note">
+            <% if @location.reserved? %>
+              <%= "Reserved by #{@location.reserved_by.name}" %>
+            <% else %>
+              (Only your team can store labware in this container)'
+            <% end %>
+          </span>
         </li>
         <li>
           <%= f.check_box :coordinateable, data: {toggle: "coordinates"} %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module Labwhere
 
     config.autoload_paths += %W(#{config.root}/lib/utils #{config.root}/lib/validators)
 
-    config.autoload_paths += %W(#{config.root}/app/models/users #{config.root}/app/models/locations)
+    config.autoload_paths += %W(#{config.root}/app/models/users #{config.root}/app/models/locations #{config.root}/app/models/restrictions)
 
     config.autoload_paths += %W(#{config.root}/lib/label_printing)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,9 @@ en:
       container: "is not a container"
       active: "is not active"
       authorised: "is not authorised"
+      reserved: "is reserved by another team (%{team})"
       location_type_in_use: "Can't delete a location type which is being used for a location."
+      location_release: "Location can only be released by the team that reserved it (%{team})"
 
   printing:
     success: "Barcode was successfully printed"

--- a/db/migrate/20160622130259_add_team_ref_to_location.rb
+++ b/db/migrate/20160622130259_add_team_ref_to_location.rb
@@ -1,0 +1,5 @@
+class AddTeamRefToLocation < ActiveRecord::Migration
+  def change
+    add_reference :locations, :team, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20160630144841_create_restriction_table.rb
+++ b/db/migrate/20160630144841_create_restriction_table.rb
@@ -1,0 +1,10 @@
+class CreateRestrictionTable < ActiveRecord::Migration
+  def change
+    create_table :restrictions do |t|
+      t.string :type
+      t.string :validator
+      t.text :params
+      t.references :location_type, index: true, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20160701091211_create_location_types_restriction_join_table.rb
+++ b/db/migrate/20160701091211_create_location_types_restriction_join_table.rb
@@ -1,0 +1,8 @@
+class CreateLocationTypesRestrictionJoinTable < ActiveRecord::Migration
+  def change
+    create_join_table :location_types, :restrictions do |t|
+      # t.index [:location_type_id, :restriction_id]
+      t.index [:restriction_id, :location_type_id], unique: true, name: "restriction_id_and_location_type_id_index"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160622130259) do
+ActiveRecord::Schema.define(version: 20160701091211) do
 
   create_table "audits", force: :cascade do |t|
     t.integer  "auditable_id"
@@ -56,6 +56,13 @@ ActiveRecord::Schema.define(version: 20160622130259) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "location_types_restrictions", id: false, force: :cascade do |t|
+    t.integer "location_type_id", null: false
+    t.integer "restriction_id",   null: false
+  end
+
+  add_index "location_types_restrictions", ["restriction_id", "location_type_id"], name: "restriction_id_and_location_type_id_index", unique: true
+
   create_table "locations", force: :cascade do |t|
     t.string   "name"
     t.string   "barcode"
@@ -81,6 +88,15 @@ ActiveRecord::Schema.define(version: 20160622130259) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "restrictions", force: :cascade do |t|
+    t.string  "type"
+    t.string  "validator"
+    t.text    "params"
+    t.integer "location_type_id"
+  end
+
+  add_index "restrictions", ["location_type_id"], name: "index_restrictions_on_location_type_id"
 
   create_table "scans", force: :cascade do |t|
     t.integer  "status",      default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160519085618) do
+ActiveRecord::Schema.define(version: 20160622130259) do
 
   create_table "audits", force: :cascade do |t|
     t.integer  "auditable_id"
@@ -70,9 +70,11 @@ ActiveRecord::Schema.define(version: 20160519085618) do
     t.integer  "location_type_id"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
+    t.integer  "team_id"
   end
 
   add_index "locations", ["location_type_id"], name: "index_locations_on_location_type_id"
+  add_index "locations", ["team_id"], name: "index_locations_on_team_id"
 
   create_table "printers", force: :cascade do |t|
     t.string   "name"

--- a/lib/tasks/invalid_locations.rake
+++ b/lib/tasks/invalid_locations.rake
@@ -1,0 +1,27 @@
+desc "Print out all the locations that fail validation"
+task :invalid_locations => :environment do
+
+  has_failures = false
+  format="%-20s\t%-20s\t%-20s\t%-20s\n"
+
+  Location.all.each do |location|
+    unless location.valid?
+
+      # Print out some nicely formatted headers
+      unless has_failures
+        printf(format, "Name", "Location Type", "Parentage", "Parent Location Type")
+        printf(format, "----", "-------------", "---------", "--------------------")
+      end
+
+      # NullLocation doesn't have a LocationType so we need to do a check first
+      parent_name = location.parent.location_type.name if location.parent.respond_to? :location_type
+
+      printf(format, location.name, location.location_type.name, location.parentage, parent_name)
+
+      has_failures = true
+    end
+  end
+
+  puts "All locations passed" unless has_failures
+
+end

--- a/lib/validators/container_reservation_validator.rb
+++ b/lib/validators/container_reservation_validator.rb
@@ -1,0 +1,7 @@
+class ContainerReservationValidator < ActiveModel::Validator
+  def validate(record)
+    if record.team.present? && !record.container?
+      record.errors.add(:base, 'Only Locations which are containers can be reserved')
+    end
+  end
+end

--- a/lib/validators/empty_parent_validator.rb
+++ b/lib/validators/empty_parent_validator.rb
@@ -1,0 +1,5 @@
+class EmptyParentValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors[:parent] << "must be empty" if record.parent.present?
+  end
+end

--- a/lib/validators/location_release_validator.rb
+++ b/lib/validators/location_release_validator.rb
@@ -1,0 +1,9 @@
+class LocationReleaseValidator < ActiveModel::Validator
+  def validate(record)
+    if record.model.team_id_changed?
+      unless record.model.team_id_was === options[:team_id]
+        record.errors.add(:base, I18n.t("errors.messages.location_release", team: record.model.reload.team.name))
+      end
+    end
+  end
+end

--- a/lib/validators/location_validator.rb
+++ b/lib/validators/location_validator.rb
@@ -10,8 +10,13 @@ class LocationValidator < ActiveModel::Validator
       record.errors.add(:location, I18n.t("errors.messages.container")) unless record.location.container?
       record.errors.add(:location, I18n.t("errors.messages.active")) unless record.location.active?
       NestedValidator.new({attributes: :location}).validate_each(record, :location, record.location)
+
+      if (record.location.reserved? && record.location.team_id != record.current_user.team_id)
+        record.errors.add(:location, I18n.t("errors.messages.reserved", team: record.location.team.name))
+      end
+
     else
       record.errors.add(:location, I18n.t("errors.messages.existence")) if record.location_barcode.present?
     end
-  end  
+  end
 end

--- a/lib/validators/parent_black_list_validator.rb
+++ b/lib/validators/parent_black_list_validator.rb
@@ -1,0 +1,7 @@
+class ParentBlackListValidator < ActiveModel::Validator
+  def validate(record)
+    if record.parent.present? and record.parent.location_type.in?(options[:location_types])
+      record.errors[:parent] << "can not be any of the following types: #{options[:location_types].map(&:name).join(", ")}"
+    end
+  end
+end

--- a/lib/validators/parent_location_validator.rb
+++ b/lib/validators/parent_location_validator.rb
@@ -1,9 +1,0 @@
-class ParentLocationValidator < ActiveModel::Validator
-  def validate(record)
-    if record.location_type.present?
-      if LocationType.not_building?(record.location_type) and LocationType.not_site?(record.location_type) and record.parent.empty?
-        record.errors[:parent] << "can only be blank for buildings"
-      end
-    end
-  end
-end

--- a/lib/validators/parent_white_list_validator.rb
+++ b/lib/validators/parent_white_list_validator.rb
@@ -1,0 +1,7 @@
+class ParentWhiteListValidator < ActiveModel::Validator
+  def validate(record)
+    unless record.parent.present? and record.parent.location_type.in?(options[:location_types])
+      record.errors[:parent] << "must be one of the following types: #{options[:location_types].map(&:name).join(", ")}"
+    end
+  end
+end

--- a/spec/api/locations_spec.rb
+++ b/spec/api/locations_spec.rb
@@ -151,5 +151,5 @@ RSpec.describe Api::LocationsController, type: :request do
     json = ActiveSupport::JSON.decode(response.body)
     expect(json).to be_empty
   end
-  
+
 end

--- a/spec/factories/location_type.rb
+++ b/spec/factories/location_type.rb
@@ -2,6 +2,10 @@ FactoryGirl.define do
   factory :location_type do
     sequence(:name) {|n| "Location Type #{n}" }
 
+    after(:create) do |location_type, evaluator|
+      create_list(:restriction, 3, location_type: location_type)
+    end
+
     factory :location_type_with_audits do
       transient do
         user { create(:user)}
@@ -9,7 +13,7 @@ FactoryGirl.define do
 
       after(:create) do |location_type, evaluator|
         1.upto(5) do |n|
-          FactoryGirl.create(:audit, auditable_type: location_type.class, 
+          FactoryGirl.create(:audit, auditable_type: location_type.class,
             auditable_id: location_type.id, user: evaluator.user, record_data: location_type)
         end
       end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:name) {|n| "Location #{n}" }
     location_type_id { LocationType.find_or_create_by(name: "Building").id }
     parent nil
+    team nil
 
     factory :location_with_parent do
       parent { FactoryGirl.create(:location)}
@@ -76,14 +77,14 @@ FactoryGirl.define do
 
       after(:create) do |location, evaluator|
         1.upto(5) do |n|
-          FactoryGirl.create(:audit, auditable_type: location.class, 
+          FactoryGirl.create(:audit, auditable_type: location.class,
             auditable_id: location.id, user: evaluator.user, record_data: location)
         end
       end
     end
 
     factory :unknown_location, class: "UnknownLocation" do
-      
+
     end
 
   end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :location do
     sequence(:name) {|n| "Location #{n}" }
-    location_type_id { LocationType.find_or_create_by(name: "Building").id }
+    location_type_id { create(:location_type).id }
     parent nil
     team nil
 

--- a/spec/factories/restrictions.rb
+++ b/spec/factories/restrictions.rb
@@ -1,0 +1,21 @@
+class MyFakeValidator < ActiveModel::Validator
+  def validate(record)
+  end
+end
+
+FactoryGirl.define do
+
+  factory :restriction do
+    location_type
+    validator { MyFakeValidator }
+
+    factory :parentage_restriction, class: "ParentageRestriction" do
+
+      after(:create) do |parentage_restriction, evaluator|
+        1.upto(2) { parentage_restriction.location_types << FactoryGirl.create(:location_type) }
+      end
+
+    end
+  end
+
+end

--- a/spec/features/locations_spec.rb
+++ b/spec/features/locations_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Locations", type: :feature do
   let!(:location_types)   { create_list(:location_type, 4)}
   let!(:parent_location)  { create(:unordered_location)}
 
-  
+
   it "Allows a user to add a new location" do
     location = build(:location)
     visit locations_path
@@ -89,6 +89,7 @@ RSpec.describe "Locations", type: :feature do
       check "Container"
       click_button "Create Location"
     }.to change(Location, :count).by(1)
+    expect(Location.last.reserved?).to eq(false)
     expect(page).to have_content("Location successfully created")
   end
 
@@ -103,11 +104,31 @@ RSpec.describe "Locations", type: :feature do
         select parent_location.id, from: "Parent"
         select location_types.first.name, from: "Location type"
         check "Has Co-ordinates"
-        fill_in "Rows", with: location.rows 
+        fill_in "Rows", with: location.rows
         fill_in "Columns", with: location.columns
         click_button "Create Location"
       }.to change(Location, :count).by(1)
       expect(OrderedLocation.first.coordinates.count).to eq(create(:ordered_location).coordinates.length)
+      expect(page).to have_content("Location successfully created")
+    end
+  end
+
+  describe "reserved", js: true do
+    it "Allows a user to new location that is reserved for their team" do
+      location = build(:ordered_location)
+      visit locations_path
+      click_link "Add new location"
+
+      expect {
+        fill_in "User swipe card id/barcode", with: user.swipe_card_id
+        fill_in "Name", with: location.name
+        select parent_location.id, from: "Parent"
+        select location_types.first.name, from: "Location type"
+        check "Reserve?"
+        click_button "Create Location"
+      }.to change(Location, :count).by(1)
+
+      expect(Location.last.team).to eq(user.team)
       expect(page).to have_content("Location successfully created")
     end
   end
@@ -147,6 +168,46 @@ RSpec.describe "Locations", type: :feature do
       click_button "Update Location"
     }.to change { location.reload.name }.to("An updated location name")
     expect(page).to have_content("Location successfully updated")
+  end
+
+  it "Allows a user to reserve a Location" do
+    location = create(:location)
+
+    visit edit_location_path(location)
+
+    expect {
+      fill_in "User swipe card id/barcode", with: user.swipe_card_id
+      check "Reserve?"
+      click_button "Update Location"
+    }.to change { location.reload.team }.to(user.team)
+
+    expect(page).to have_content("Location successfully updated")
+  end
+
+  it "Allows a user to release a Location" do
+    location = create(:location, team: user.team)
+
+    visit edit_location_path(location)
+
+    expect {
+      fill_in "User swipe card id/barcode", with: user.swipe_card_id
+      uncheck "Reserve?"
+      click_button "Update Location"
+    }.to change { location.reload.team }.to(nil)
+
+    expect(page).to have_content("Location successfully updated")
+  end
+
+  it "Does not allow a user to release a Location not reserved by their team" do
+    reserved_location = create(:location, team: create(:team))
+
+    visit edit_location_path(reserved_location)
+
+    fill_in "User swipe card id/barcode", with: user.swipe_card_id
+    uncheck "Reserve?"
+    click_button "Update Location"
+
+    expect(page.text).to match("error prohibited this record from being saved")
   end
 
   it "Allows a user to nest locations" do

--- a/spec/features/locations_spec.rb
+++ b/spec/features/locations_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe "Locations", type: :feature do
     expect {
       fill_in "User swipe card id/barcode", with: user.swipe_card_id
       fill_in "Name", with: location.name
-      select 'Building', from: "Location type"
       check "Container"
       click_button "Create Location"
     }.to change(Location, :count).by(1)
@@ -268,7 +267,6 @@ RSpec.describe "Locations", type: :feature do
     expect {
       fill_in "User swipe card id/barcode", with: scientist.swipe_card_id
       fill_in "Name", with: location.name
-      select 'Building', from: "Location type"
       check "Container"
       click_button "Create Location"
     }.to_not change(Location, :count)

--- a/spec/models/concerns/reservable_spec.rb
+++ b/spec/models/concerns/reservable_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Reservable, type: :model do
+
+  with_model :MyModel do
+
+    table do |t|
+      t.integer :team_id
+    end
+
+    model do
+      belongs_to :team
+      include Reservable
+    end
+
+  end
+
+  let(:model)            { MyModel.create }
+  let(:reserved_model)  { MyModel.create(team: create(:team)) }
+
+  describe '#reserved?' do
+    it 'is true when it has an associated team' do
+      expect(reserved_model.reserved?).to eq(true)
+    end
+
+    it 'is false when it does not have an associated team' do
+      expect(model.reserved?).to eq(false)
+    end
+  end
+
+  describe '#reserve' do
+    it 'sets the team on the model' do
+      team = create(:team)
+      expect(model.reserve(team)).to be_truthy
+      expect(model.reserved?).to eq(true)
+    end
+
+    it 'returns false if there is already a team' do
+      expect(reserved_model.reserve(create(:team))).to eql(false)
+    end
+  end
+
+  describe '#release' do
+    it 'sets the team to nil' do
+      expect(reserved_model.release).to be_truthy
+      expect(reserved_model.reserved?).to eq(false)
+    end
+  end
+
+  describe '#reserved_by' do
+    it 'returns the team that has reserved the model' do
+      expect(reserved_model.reserved_by).to be(reserved_model.team)
+    end
+
+    it 'returns nil if the model is not reserved' do
+      expect(model.reserved_by).to be_nil
+    end
+  end
+
+end

--- a/spec/models/labware_collection_spec.rb
+++ b/spec/models/labware_collection_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe LabwareCollection, type: :model do
 
-  let!(:previous_location_1)    { create(:location_with_parent)}    
-  let!(:previous_location_2)    { create(:location_with_parent)}    
+  let!(:previous_location_1)    { create(:location_with_parent)}
+  let!(:previous_location_2)    { create(:location_with_parent)}
   let!(:labwares_1)             { create_list(:labware, 5, location: previous_location_1) }
   let!(:labwares_2)             { create_list(:labware, 5, location: previous_location_2) }
   let(:new_labwares)            { build_list(:labware, 5)}
@@ -36,7 +36,6 @@ RSpec.describe LabwareCollection, type: :model do
       end
     end
 
-    
   end
 
   describe 'adding to an ordered location' do
@@ -73,5 +72,5 @@ RSpec.describe LabwareCollection, type: :model do
 
   end
 
-  
+
 end

--- a/spec/models/location_type_spec.rb
+++ b/spec/models/location_type_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe LocationType, type: :model do 
+RSpec.describe LocationType, type: :model do
 
   it "is invalid without a name" do
     expect(build(:location_type, name: nil)).to_not be_valid
@@ -49,33 +49,6 @@ RSpec.describe LocationType, type: :model do
     location_type.destroy
     expect(location_type).to_not be_destroyed
     expect(location_type.errors).to_not be_empty
-  end
-
-  it "#building  should return location type of building" do
-    location_type = create(:location_type)
-    building = create(:location_type, name: "Building")
-    expect(LocationType.building).to eq(building)
-  end
-
-  it "#building? should check whether location type is a building" do
-    location_type = create(:location_type)
-    building = create(:location_type, name: "Building")
-    expect(LocationType.not_building?(location_type)).to be_truthy
-    expect(LocationType.building?(building)).to be_truthy
-
-  end
-
-   it "#site  should return location type of site" do
-    location_type = create(:location_type)
-    site = create(:location_type, name: "Site")
-    expect(LocationType.site).to eq(site)
-  end
-
-  it "#site? should check whether location type is a site" do
-    location_type = create(:location_type)
-    site = create(:location_type, name: "Site")
-    expect(LocationType.not_site?(location_type)).to be_truthy
-    expect(LocationType.site?(site)).to be_truthy
   end
 
 end

--- a/spec/models/locations/location_spec.rb
+++ b/spec/models/locations/location_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Location, type: :model do
     expect(build(:location, name: "unknown")).to_not be_valid
   end
 
+  it "is invalid if is container and has a team" do
+    expect(build(:location, container: 0, team: create(:team))).to_not be_valid
+  end
+
   it "#without_location should return a list of locations without a specified location" do
     locations         = create_list(:location, 3)
     inactive_location = create(:location, status: Location.statuses[:inactive])
@@ -214,5 +218,6 @@ RSpec.describe Location, type: :model do
     building_type = create(:location_type, name: "Bin")
 
     expect(build(:location, location_type: building_type)).to_not be_valid
-    end
+  end
+
 end

--- a/spec/models/locations/location_spec.rb
+++ b/spec/models/locations/location_spec.rb
@@ -21,6 +21,68 @@ RSpec.describe Location, type: :model do
     expect(build(:location, container: 0, team: create(:team))).to_not be_valid
   end
 
+  context "when location type has empty parent restriction" do
+
+    before(:each) do
+      restriction = create(:restriction, validator: EmptyParentValidator)
+      @location_type = create(:location_type)
+      @location_type.restrictions << restriction
+    end
+
+    it "is invalid with a parent" do
+      location = build(:location_with_parent, location_type: @location_type)
+      expect(location).to_not be_valid
+    end
+
+    it "is valid without a parent" do
+      location = build(:location, location_type: @location_type)
+      expect(location).to be_valid
+    end
+  end
+
+  context "when location type has enforced parent types" do
+
+    before(:each) do
+      @restriction = create(:parentage_restriction, validator: ParentWhiteListValidator)
+      @location_type = create(:location_type)
+      @location_type.restrictions << @restriction
+    end
+
+    it "is valid with a parent that is one of the enforced types" do
+      parent_location = build(:location, location_type: @restriction.location_types.first)
+      location = build(:location, parent: parent_location, location_type: @location_type)
+
+      expect(location).to be_valid
+    end
+
+    it "is invalid with a parent that is not one of the enforced location types" do
+      parent_location = build(:location)
+      location = build(:location, parent: parent_location, location_type: @location_type)
+
+      expect(location).to_not be_valid
+    end
+  end
+
+  context "when location type has restricted parent types" do
+
+    before(:each) do
+      @restriction = create(:parentage_restriction, validator: ParentBlackListValidator)
+      @location_type = create(:location_type)
+      @location_type.restrictions << @restriction
+    end
+
+    it "is valid when parent is not a restricted type" do
+      location = build(:location_with_parent, location_type: @location_type)
+      expect(location).to be_valid
+    end
+
+    it "is invalid when parent is a restricted type" do
+      parent_location = build(:location, location_type: @restriction.location_types.first)
+      location = build(:location, location_type: @location_type, parent: parent_location)
+      expect(location).to_not be_valid
+    end
+  end
+
   it "#without_location should return a list of locations without a specified location" do
     locations         = create_list(:location, 3)
     inactive_location = create(:location, status: Location.statuses[:inactive])
@@ -125,18 +187,10 @@ RSpec.describe Location, type: :model do
     expect(location.available_coordinates(10)).to be_empty
   end
 
-  it "#by_building should return locations which have a location type of building" do
-
-    building = create(:location_type, name: "Building")
-    site     = create(:location_type, name: "Site")
-    room     = create(:location_type, name: "Room")
-
-    locations_1 = create_list(:location, 3, location_type: building)
-    locations_2 = create_list(:location, 3, location_type: site, parent: locations_1.first)
-    locations_3 = create_list(:location, 3, location_type: room, parent: locations_1.first)
-
-    expect(Location.by_building.count).to eq(3)
-    expect(Location.by_building.first).to eq(locations_1.first)
+  it "#by_root should return locations which have no parent" do
+    locations_with_parents = create_list(:location_with_parent, 3)
+    locations_without_parents = create_list(:location, 3)
+    expect(Location.by_root.count).to eq(6)
   end
 
   it '#should allow the same name with different parents' do
@@ -197,27 +251,6 @@ RSpec.describe Location, type: :model do
         expect(create(:location).has_child_locations?).to eql(false)
       end
     end
-  end
-
-  it 'should allow buildings or sites with no parent' do
-    building_type = create(:location_type, name: "Building")
-    site_type = create(:location_type, name: "Site")
-
-    expect(build(:location, location_type: building_type)).to be_valid
-    expect(build(:location, location_type: site_type)).to be_valid
-  end
-
-  it "should not allow empty parent when location type is not a building or site" do
-    location_type = create(:location_type, name: "Not a Building or Site")
-
-    expect(build(:location, location_type: location_type)).to_not be_valid
-
-  end
-
-  it 'should not allow bins with no parent' do
-    building_type = create(:location_type, name: "Bin")
-
-    expect(build(:location, location_type: building_type)).to_not be_valid
   end
 
 end

--- a/spec/models/restrictions/parentage_restriction_spec.rb
+++ b/spec/models/restrictions/parentage_restriction_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ParentageRestriction, type: :model do
+
+  let(:parentage_restriction) { create(:parentage_restriction) }
+
+  it "returns location_types in the params" do
+    expect(parentage_restriction.params).to include(:location_types)
+  end
+
+end

--- a/spec/models/restrictions/restriction_spec.rb
+++ b/spec/models/restrictions/restriction_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Restriction, type: :model do
+
+  it "is not valid without a validator" do
+    expect(build(:restriction, validator: nil)).to be_invalid
+  end
+
+  it "returns validator as a constant" do
+    expect(build(:restriction).validator).to be_kind_of(Class)
+  end
+
+  context "when params is empty" do
+    it "returns a hash" do
+      expect(build(:restriction).params).to eql({})
+    end
+  end
+
+end

--- a/spec/models/validators/empty_parent_spec.rb
+++ b/spec/models/validators/empty_parent_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe EmptyParentValidator, type: :model do
+
+  let(:validator) { EmptyParentValidator.new }
+  let(:location_with_parent) { create(:location_with_parent) }
+  let(:location) { create(:location) }
+
+  context 'when model has no parent' do
+    it 'is valid' do
+      validator.validate(location)
+      expect(location.errors).to be_empty
+    end
+  end
+
+  context 'when model has a parent' do
+    it 'is invalid' do
+      validator.validate(location_with_parent)
+      expect(location_with_parent).to_not be_empty
+    end
+  end
+
+end

--- a/spec/models/validators/parent_black_list_spec.rb
+++ b/spec/models/validators/parent_black_list_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe ParentBlackListValidator, type: :model do
+
+  let(:invalid_parent_types) { create_list(:location_type, 3) }
+
+  let(:validator) do
+    ParentBlackListValidator.new(location_types: invalid_parent_types)
+  end
+
+  let(:model_with_valid_parent) do
+    create(:location, parent: create(:location_with_parent))
+  end
+
+  let(:model_with_invalid_parent) do
+    location_of_invalid_type = create(:location, location_type: invalid_parent_types.first)
+    create(:location, parent: location_of_invalid_type)
+  end
+
+  let(:model_with_no_parent) { create(:location) }
+
+  context 'when model has no parent' do
+    it 'is valid' do
+      validator.validate(model_with_no_parent)
+      expect(model_with_no_parent.errors).to be_empty
+    end
+  end
+
+  context 'when model parent has a permitted location type' do
+    it 'is valid' do
+      validator.validate(model_with_valid_parent)
+      expect(model_with_valid_parent.errors).to be_empty
+    end
+  end
+
+  context 'when model parent has a restricted location type' do
+    it 'is invalid' do
+      validator.validate(model_with_invalid_parent)
+      expect(model_with_invalid_parent.errors).to_not be_empty
+    end
+  end
+
+end

--- a/spec/models/validators/parent_white_list_spec.rb
+++ b/spec/models/validators/parent_white_list_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ParentWhiteListValidator, type: :model do
+
+  let(:valid_parent_types) { create_list(:location_type, 3) }
+
+  let(:validator) do
+    ParentWhiteListValidator.new(location_types: valid_parent_types)
+  end
+
+  let(:model_with_valid_parent) do
+    location_of_valid_type = create(:location, location_type: valid_parent_types.first)
+    create(:location, parent: location_of_valid_type)
+  end
+
+  let(:model_with_invalid_parent) { create(:location_with_parent) }
+
+  context 'when model parent has a permitted location type' do
+    it 'is valid' do
+      validator.validate(model_with_valid_parent)
+      expect(model_with_valid_parent.errors).to be_empty
+    end
+  end
+
+  context 'when model parent has a restricted location type' do
+    it 'is invalid' do
+      validator.validate(model_with_invalid_parent)
+      expect(model_with_invalid_parent.errors).to_not be_empty
+    end
+  end
+
+end


### PR DESCRIPTION
A team must release a location before another team can reserve it
Locations with reserved ancestors can not be scanned into by other teams
Locations with reserved ancestors can not be scanned out of by other
teams