### PR TITLE
updated bundler.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/sanger/pmb-client.git
+  remote: https://github.com/sanger/pmb-client.git
   revision: 016f151a3bde84448ed64e528259c3511282dcdb
   specs:
     pmb-client (0.1.0)
@@ -400,4 +400,4 @@ DEPENDENCIES
   with_model
 
 BUNDLED WITH
-   1.12.5
+   2.1.4

--- a/app/views/move_locations/_form.html.erb
+++ b/app/views/move_locations/_form.html.erb
@@ -6,11 +6,11 @@
         <%= render "user_code", object: f %>
       </li>
       <li>
-        <div><%= f.label :parent_location_barcode, 'Parent location barcode*' %> </div>
+        <div><%= f.label :parent_location_barcode, 'New location barcode (Parent location)*' %> </div>
         <div><%= f.text_field :parent_location_barcode %></div>
       </li>
       <li>
-        <div><%= f.label :child_location_barcodes, 'Child location barcodes*' %></div>
+        <div><%= f.label :child_location_barcodes, 'Location barcodes to be moved (Child location)*' %></div>
         <div class="pr-5"><%= f.text_area :child_location_barcodes %></div>
       </li>
       <li>

--- a/app/views/move_locations/_form.html.erb
+++ b/app/views/move_locations/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for @move_locations, url: move_locations_path do |f| %>
   <fieldset>
-    <legend>Scan In/Out</legend>
+    <legend>Move Locations</legend>
     <ul>
       <li>
         <%= render "user_code", object: f %>

--- a/spec/features/move_locations_spec.rb
+++ b/spec/features/move_locations_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "MoveLocations", type: :feature do
     visit new_move_location_path
     expect do
       fill_in "User swipe card id/barcode", with: user.swipe_card_id
-      fill_in "Parent location barcode", with: parent_location.barcode
-      fill_in "Child location barcodes", with: child_locations.join_barcodes
+      fill_in "New location barcode (Parent location)", with: parent_location.barcode
+      fill_in "Location barcodes to be moved (Child location)", with: child_locations.join_barcodes
       click_button "Go!"
     end.to change(parent_location.reload.children, :count).by(5)
     expect(page).to have_content("Locations successfully moved")
@@ -24,8 +24,8 @@ RSpec.describe "MoveLocations", type: :feature do
     visit new_move_location_path
     expect do
       fill_in "User swipe card id/barcode", with: user.swipe_card_id
-      fill_in "Parent location barcode", with: parent_location.barcode
-      fill_in "Child location barcodes", with: child_locations.join_barcodes + "\nlw-no-location-here"
+      fill_in "New location barcode (Parent location)", with: parent_location.barcode
+      fill_in "Location barcodes to be moved (Child location)", with: child_locations.join_barcodes + "\nlw-no-location-here"
       click_button "Go!"
     end.to_not change(parent_location.children, :count)
     expect(page).to have_content("error prohibited this record from being saved")


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* Fix deployment problems.

Getting error

```
STDOUT:

bundler: failed to load command: rake (/var/www/labwhere/shared/vendor/bundle/ruby/2.5.0/bin/rake)


STDERR:

/home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/bundler-1.12.5/lib/bundler/rubygems_integration.rb:152: warning: constant Gem::ConfigMap is deprecated
Gem::UnsatisfiableDependencyError: Unable to resolve dependency: user requested 'did_you_mean (= 1.2.0)'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver.rb:235:in `search_for'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver.rb:285:in `block in sort_dependencies'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver.rb:279:in `each'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver.rb:279:in `sort_by'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver.rb:279:in `with_index'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver.rb:279:in `sort_dependencies'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:52:in `block in sort_dependencies'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:69:in `with_no_such_dependency_error_handling'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:51:in `sort_dependencies'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:165:in `initial_state'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:106:in `start_resolution'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:64:in `resolve'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:42:in `resolve'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/resolver.rb:192:in `resolve'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/request_set.rb:423:in `resolve'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems/request_set.rb:435:in `resolve_current'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems.rb:236:in `finish_resolve'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems.rb:299:in `block in activate_bin_path'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems.rb:297:in `synchronize'
  /home/ubuntu/.rbenv/versions/2.5.6/lib/ruby/site_ruby/2.5.0/rubygems.rb:297:in `activate_bin_path'
  /var/www/labwhere/shared/vendor/bundle/ruby/2.5.0/bin/rake:23:in `<top (required)>'


MSG:

non-zero return code
```
