### PR TITLE
GPL-586 new Labwhere endpoint - labwares by locations

### DIFF
--- a/app/controllers/api/labwares_controller.rb
+++ b/app/controllers/api/labwares_controller.rb
@@ -5,9 +5,23 @@ class Api::LabwaresController < ApiController
     render json: current_resource
   end
 
+  def index
+    # doesn't currently include a basic index function, returning all labwares, but could in future
+    render json: labwares_by_location
+  end
+
   private
 
   def current_resource
     Labware.find_by_code(params[:barcode]) if params[:barcode]
+  end
+
+  def labwares_by_location
+    # expects url param of location barcode(s)
+    # for example, ?location_barcodes=lw-uk-biocentre-mk-6-3662,lw-reefer-1-33
+    location_barcodes = params[:location_barcodes]
+    return unless location_barcodes
+
+    Labware.joins(:location).where(locations: { barcode: location_barcodes.split(',') })
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,7 +92,7 @@ Rails.application.routes.draw do
 
     resources :scans, only: [:create]
 
-    resources :labwares, param: :barcode, only: [:show] do
+    resources :labwares, param: :barcode, only: [:show, :index] do
       concerns :auditable, parent: :labwares
     end
 

--- a/spec/api/labwares_spec.rb
+++ b/spec/api/labwares_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Retrieve location information for a given piece of labware (GET /api/labwares/<barcode>) returns labware object and location object
+# Retrieve labwares for a given list of locations barcodes (GET /api/labwares?location_barcodes=<barcode_1>,<barcode_2>...)
 
 require "rails_helper"
 
@@ -8,33 +9,88 @@ RSpec.describe Api::LabwaresController, type: :request do
   let!(:location) { create(:location_with_parent) }
   let!(:labware) { create(:labware_with_audits, location: location) }
 
-  before(:each) do
-    get api_labware_path(labware.barcode)
-    @json = ActiveSupport::JSON.decode(response.body)
+  describe '#show' do
+    before(:each) do
+      get api_labware_path(labware.barcode)
+      @json = ActiveSupport::JSON.decode(response.body)
+    end
+
+    it "should be a success" do
+      expect(response).to be_successful
+    end
+
+    it "should return labware barcode" do
+      expect(@json["barcode"]).to eq(labware.barcode)
+    end
+
+    it "should return location object associated with labware" do
+      expect(@json["location"]).to_not be_empty
+    end
+
+    it "should return link to labware audits" do
+      expect(@json["audits"]).to eq(api_labware_audits_path(labware.barcode))
+    end
+
+    it "link to labware audits should return audits for labware" do
+      get @json["audits"]
+      expect(response).to be_successful
+      json = ActiveSupport::JSON.decode(response.body).first
+      audit = labware.audits.first
+      expect(json["user"]).to eq(audit.user.login)
+      expect(json["created_at"]).to eq(audit.created_at.to_s(:uk))
+    end
   end
 
-  it "should be a success" do
-    expect(response).to be_successful
-  end
+  describe '#index' do
+    let!(:location_multiple_labware) { location }
+    let!(:labware_2) { create(:labware_with_audits, location: location_multiple_labware) }
+    let!(:labware_3) { create(:labware_with_audits, location: location_multiple_labware) }
 
-  it "should return labware barcode" do
-    expect(@json["barcode"]).to eq(labware.barcode)
-  end
+    let!(:location_empty) { create(:location_with_parent) }
 
-  it "should return location object associated with labware" do
-    expect(@json["location"]).to_not be_empty
-  end
+    let!(:location_single_labware) { create(:location_with_parent) }
+    let!(:labware_4) { create(:labware_with_audits, location: location_single_labware) }
 
-  it "should return link to labware audits" do
-    expect(@json["audits"]).to eq(api_labware_audits_path(labware.barcode))
-  end
+    let!(:location_barcodes_params) do
+      {
+        'location_barcodes' => "#{location_multiple_labware.barcode},#{location_empty.barcode},#{location_single_labware.barcode}",
+        'controller' => 'api/labwares',
+        'action' => 'index'
+      }
+    end
 
-  it "link to labware audits should return audits for labware" do
-    get @json["audits"]
-    expect(response).to be_successful
-    json = ActiveSupport::JSON.decode(response.body).first
-    audit = labware.audits.first
-    expect(json["user"]).to eq(audit.user.login)
-    expect(json["created_at"]).to eq(audit.created_at.to_s(:uk))
+    context 'with location barcodes parameter' do
+      before(:each) do
+        get api_labwares_path(location_barcodes_params)
+        @json = ActiveSupport::JSON.decode(response.body)
+      end
+
+      it "should be a success" do
+        expect(response).to be_successful
+      end
+
+      it "should return all labwares" do
+        expect(@json.size).to eq(4)
+      end
+
+      it "should return labware barcodes" do
+        expect(@json[0]["barcode"]).to_not be_nil
+      end
+
+      it "should return location object associated with labware" do
+        expect(@json[0]["location"]).to_not be_empty
+      end
+    end
+
+    context 'with no parameters' do
+      before(:each) do
+        get api_labwares_path(labware.barcode)
+        @json = ActiveSupport::JSON.decode(response.body)
+      end
+
+      it 'should not return a body' do
+        expect(@json).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
For GPL-559 (https://github.com/sanger/lighthouse-ui/issues/10)

Add new endpoint to get all labwares at locations as specified by location barcodes

- GET operation
- index action
- e.g. /api/labwares?location_barcodes=abc,def,ghi
- returns list of labware objects