### PR TITLE
GPL-751 BUG - Re-firing LabWhere events gives wrong location

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,9 +9,7 @@ class Event
 
   validate :check_location_exists
 
-  def uuid
-    @uuid ||= audit.uuid
-  end
+  delegate :uuid, to: :audit
 
   def event_type
     @event_type ||= Event.generate_event_type(audit.action)
@@ -28,10 +26,7 @@ class Event
   end
 
   def location
-    @location ||= begin
-      location_barcode = audit.record_data['location']
-      Location.find_by(barcode: location_barcode)
-    end
+    @location ||= Location.find_by(barcode: audit.record_data['location'])
   end
 
   def coordinate
@@ -39,10 +34,8 @@ class Event
       if audit.id == labware.audits.last.id
         # if this is the latest audit for this labware, we can grab the current coordinate from the labware
         labware.coordinate
-      else
-        # otherwise, we are re-firing an old event and don't know the correct coordinate for the time it occurred
-        nil
       end
+      # otherwise, return nil as we're re-firing an old event & don't know the coordinate for the time it occurred
     end
   end
 

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -10,5 +10,18 @@ FactoryBot.define do
     record_data  { location }
     auditable_id { location.id }
     user
+
+    factory :audit_of_labware do
+      transient do
+        labware { create(:labware_with_location) }
+      end
+      auditable_type { labware.class }
+      action "create"
+      record_data  { labware }
+      auditable_id { labware.id }
+      user
+    end
   end
+
+
 end

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -22,6 +22,4 @@ FactoryBot.define do
       user
     end
   end
-
-
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :event do
     labware { create(:labware_with_location) }
-    audit { create(:audit) }
+    audit { create(:audit_of_labware, labware: labware) }
   end
 end

--- a/spec/messages/message_spec.rb
+++ b/spec/messages/message_spec.rb
@@ -5,7 +5,7 @@ require 'ostruct'
 
 RSpec.describe Messages::Message, type: :model do
   let(:labware) { create(:labware_with_location) }
-  let(:audit) { create(:audit) }
+  let(:audit) { create(:audit_of_labware, labware: labware) }
   let(:object) { Event.new(labware: labware, audit: audit) }
 
   describe '#payload' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,21 +4,28 @@ require 'rails_helper'
 
 RSpec.describe Event, type: :model do
   let(:labware) { create(:labware_with_location) }
-  let(:audit) { create(:audit) }
+  let(:audit) { create(:audit_of_labware, labware: labware) }
   let(:attributes) { { labware: labware, audit: audit } }
 
   it 'must have a piece of labware' do
     expect(Event.new(attributes.except(:labware))).to_not be_valid
   end
 
-  it 'must have a location' do
-    expect(Event.new(attributes.merge(labware: create(:labware)))).to_not be_valid
+  context 'without a location' do
+    let(:labware) { create(:labware) }
+
+    it 'is invalid' do
+      expect(Event.new(attributes)).to_not be_valid
+    end
   end
 
-  it 'may have a coordinate' do
-    coordinate = create(:coordinate, labware: create(:labware))
-    event = Event.new(attributes.merge(labware: coordinate.labware))
-    expect(event.coordinate).to be_present
+  context 'with a coordinate' do
+    let!(:coordinate) { create(:coordinate, labware: labware, location: labware.location) }
+
+    it 'returns the coordinate' do
+      event = Event.new(attributes)
+      expect(event.coordinate).to be_present
+    end
   end
 
   describe '#generate_event_type' do
@@ -73,22 +80,66 @@ RSpec.describe Event, type: :model do
     end
 
     it 'will produce the correct json for the message' do
-      event = Event.new(labware: labware, audit: audit)
+      event = Event.new(attributes)
       json = event.as_json
       expect(json).to eq(expected_json)
     end
   end
 
   context 'for an ordered location' do
-    let(:coordinate) { create(:coordinate, labware: create(:labware)) }
+    let!(:coordinate) { create(:coordinate, labware: labware, location: labware.location) }
 
     it 'will produce the correct json for the message' do
-      locn = coordinate.labware.location
-      event = Event.new(attributes.merge(labware: coordinate.labware))
+      locn = labware.location
+      event = Event.new(attributes)
       json = event.as_json
 
       expect(json[:event][:subjects][1][:friendly_name]).to eq(locn.barcode)
       expect(json[:event][:metadata][:location_coordinate]).to eq(coordinate.position)
+    end
+  end
+
+  context 'creating an event for an old audit' do
+    context 'where the location has changed since' do
+      let(:first_location) { labware.location }
+      let(:second_location) { create(:location_with_parent) }
+
+      before do
+        # preload things
+        first_location
+        audit
+        # change the location and coordinate on the labware
+        labware.update!(location: second_location)
+      end
+
+      it 'uses the location from the time the audit was created' do
+        event = Event.new(attributes)
+
+        expect(first_location.id).to_not eq(second_location.id) # sanity check
+        expect(event.location.id).to eq(first_location.id)
+      end
+    end
+
+    context 'where the coordinate has changed since' do
+      let(:first_coordinate) { create(:coordinate, labware: labware, location: labware.location) }
+      let(:second_coordinate) { create(:coordinate, labware: labware, location: labware.location) }
+      let(:second_audit) { create(:audit_of_labware, labware: labware) }
+
+      before do
+        # preload things
+        first_coordinate
+        audit
+        # change the location and coordinate on the labware
+        second_coordinate
+        second_audit
+      end
+
+      it 'uses the coordinate from the time the audit was created' do
+        event = Event.new(attributes)
+
+        expect(first_coordinate.id).to_not eq(second_coordinate.id) # sanity check
+        expect(event.coordinate).to eq(nil)
+      end
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Event, type: :model do
         # preload things
         first_location
         audit
-        # change the location and coordinate on the labware
+        # change the location on the labware
         labware.update!(location: second_location)
       end
 
@@ -129,7 +129,7 @@ RSpec.describe Event, type: :model do
         # preload things
         first_coordinate
         audit
-        # change the location and coordinate on the labware
+        # change the coordinate on the labware
         second_coordinate
         second_audit
       end


### PR DESCRIPTION
Fix bug with getting location and coordinate on event
- for location, always get it from the record_data field on audit
- for coordinate, get it from the labware if this is the latest audit and therefore the coordinate is still 'current'
- for coordinate, set it to null if it's not the latest audit, as we don't know the relevant coordinate (record_data doesn't store that info)
- add audit factory to link up the labwares and audits correctly, and switch tests to using that
- new tests for location and coordinate changes