### PR TITLE
Gpl 747 add known labware locations endpoint

### DIFF
--- a/app/controllers/api/labwares_controller.rb
+++ b/app/controllers/api/labwares_controller.rb
@@ -14,6 +14,10 @@ class Api::LabwaresController < ApiController
     render json: labwares_by_barcode, each_serializer: LabwareLiteSerializer
   end
 
+  def by_barcode_known
+    render json: labwares_by_barcode_known, each_serializer: LabwareLiteSerializer
+  end
+
   private
 
   def current_resource
@@ -34,5 +38,12 @@ class Api::LabwaresController < ApiController
     return [] unless barcodes
 
     Labware.by_barcode(barcodes)
+  end
+
+  def labwares_by_barcode_known
+    barcodes = params[:barcodes]
+    return [] unless barcodes
+
+    Labware.by_barcode_known(barcodes)
   end
 end

--- a/app/controllers/api/labwares_controller.rb
+++ b/app/controllers/api/labwares_controller.rb
@@ -11,11 +11,11 @@ class Api::LabwaresController < ApiController
   end
 
   def by_barcode
-    render json: labwares_by_barcode, each_serializer: LabwareLiteSerializer
-  end
-
-  def by_barcode_known
-    render json: labwares_by_barcode_known, each_serializer: LabwareLiteSerializer
+    if request.params["known"] == "true"
+      render json: labwares_by_barcode_known_locations, each_serializer: LabwareLiteSerializer
+    else
+      render json: labwares_by_barcode, each_serializer: LabwareLiteSerializer
+    end
   end
 
   private
@@ -40,10 +40,10 @@ class Api::LabwaresController < ApiController
     Labware.by_barcode(barcodes)
   end
 
-  def labwares_by_barcode_known
+  def labwares_by_barcode_known_locations
     barcodes = params[:barcodes]
     return [] unless barcodes
 
-    Labware.by_barcode_known(barcodes)
+    Labware.by_barcode_known_locations(barcodes)
   end
 end

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -24,6 +24,9 @@ class Labware < ActiveRecord::Base
   searchable_by :barcode
 
   scope :by_barcode, lambda { |barcodes| includes(:location).where(barcode: barcodes) }
+  scope :by_barcode_known, lambda { |barcodes| includes(:location)
+                                              .where(barcode: barcodes)
+                                              .where.not(location_id: UnknownLocation.get) }
 
   ##
   # find a Labware by its barcode

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -24,9 +24,11 @@ class Labware < ActiveRecord::Base
   searchable_by :barcode
 
   scope :by_barcode, lambda { |barcodes| includes(:location).where(barcode: barcodes) }
-  scope :by_barcode_known, lambda { |barcodes| includes(:location)
-                                              .where(barcode: barcodes)
-                                              .where.not(location_id: UnknownLocation.get) }
+  scope :by_barcode_known, lambda { |barcodes|
+                             includes(:location)
+                               .where(barcode: barcodes)
+                               .where.not(location_id: UnknownLocation.get)
+                           }
 
   ##
   # find a Labware by its barcode

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -24,11 +24,11 @@ class Labware < ActiveRecord::Base
   searchable_by :barcode
 
   scope :by_barcode, lambda { |barcodes| includes(:location).where(barcode: barcodes) }
-  scope :by_barcode_known, lambda { |barcodes|
-                             includes(:location)
-                               .where(barcode: barcodes)
-                               .where.not(location_id: UnknownLocation.get)
-                           }
+  scope :by_barcode_known_locations, lambda { |barcodes|
+                                       includes(:location)
+                                         .where(barcode: barcodes)
+                                         .where.not(location_id: UnknownLocation.get)
+                                     }
 
   ##
   # find a Labware by its barcode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
 
   class KnownLocationsConstraint
     def matches?(request)
-      request.query_parameters["known"] == "true"
+      request.params["known"] == "true"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,13 +63,20 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   root 'scans#new'
 
+  class KnownLocationsConstraint
+    def matches?(request)
+      request.query_parameters["known"] == "true"
+    end
+  end
+
   namespace :api do
     get 'docs', to: 'docs#index'
     post 'labwares/searches', to: 'labwares/searches#create'
     post 'labwares/locations', to: 'labwares/locations#create'
 
     # This needs to be a post due to the number of barcodes that will be passed which is not possible with a get
-    post 'labwares_by_barcode', to: 'labwares#by_barcode'
+    post 'labwares_by_barcode', to: 'labwares#by_barcode', :constraints => lambda { |request| request.params[:known] == nil }
+    post 'labwares_by_barcode', to: 'labwares#by_barcode_known', :constraints => KnownLocationsConstraint.new
     root 'docs#index'
 
     put 'coordinates', to: 'coordinates#update'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,20 +63,13 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   root 'scans#new'
 
-  class KnownLocationsConstraint
-    def matches?(request)
-      request.params["known"] == "true"
-    end
-  end
-
   namespace :api do
     get 'docs', to: 'docs#index'
     post 'labwares/searches', to: 'labwares/searches#create'
     post 'labwares/locations', to: 'labwares/locations#create'
 
     # This needs to be a post due to the number of barcodes that will be passed which is not possible with a get
-    post 'labwares_by_barcode', to: 'labwares#by_barcode', :constraints => lambda { |request| request.params[:known] == nil }
-    post 'labwares_by_barcode', to: 'labwares#by_barcode_known', :constraints => KnownLocationsConstraint.new
+    post 'labwares_by_barcode', to: 'labwares#by_barcode'
     root 'docs#index'
 
     put 'coordinates', to: 'coordinates#update'

--- a/spec/api/labwares_spec.rb
+++ b/spec/api/labwares_spec.rb
@@ -131,5 +131,33 @@ RSpec.describe Api::LabwaresController, type: :request do
         expect(labware["location_barcode"]).to_not be_present
       end
     end
+
+    context 'when known locations query parameter set' do
+      let!(:labware_unknown_location) { create(:labware, location: UnknownLocation.get) }
+      let!(:labware_null_location) { create(:labware, location: nil) }
+      let!(:barcode_unknown_location) { labware_unknown_location.barcode }
+      let!(:barcode_null_location) { labware_null_location.barcode }
+
+      before(:each) do
+        post api_labwares_by_barcode_path, params: { barcodes: barcodes + [barcode_null_location, barcode_unknown_location], known: "true" }
+        @json = ActiveSupport::JSON.decode(response.body)
+      end
+
+      it 'should produce some json' do
+        expect(@json.length).to eq(5)
+      end
+
+      it 'should not return labwares at the unknown location' do
+        labware = @json.find { |l| l["barcode"] == barcode_unknown_location }
+
+        expect(labware).to be_falsy
+      end
+
+      it 'should not return labwares with null locations' do
+        labware = @json.find { |l| l["barcode"] == barcode_null_location }
+
+        expect(labware).to be_falsy
+      end
+    end
   end
 end

--- a/spec/api/labwares_spec.rb
+++ b/spec/api/labwares_spec.rb
@@ -149,13 +149,11 @@ RSpec.describe Api::LabwaresController, type: :request do
 
       it 'should not return labwares at the unknown location' do
         labware = @json.find { |l| l["barcode"] == barcode_unknown_location }
-
         expect(labware).to be_falsy
       end
 
       it 'should not return labwares with null locations' do
         labware = @json.find { |l| l["barcode"] == barcode_null_location }
-
         expect(labware).to be_falsy
       end
     end


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

Add query parameter to by_barcode endpoint which returns the labware locations where the location is known only i.e. not null and not at the Unknown location. Lighthouse is to be changed to call the endpoint with this parameter for the generation of the positives report.
