### PR TITLE
Gpl 761 fix location audit history

### DIFF
--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -28,6 +28,7 @@ class LocationForm
           @location = new_location
           check_location
           @location.save!
+          @location.create_audit(current_user, Audit::CREATE_ACTION)
         end
       end
     else
@@ -40,7 +41,9 @@ class LocationForm
     assign_attributes(params)
     if valid?
       run_transaction do
-        location.save
+        if location.save
+          location.create_audit(current_user, Audit::UPDATE_ACTION)
+        end
       end
     else
       false
@@ -55,6 +58,7 @@ class LocationForm
 
     location.destroy
     if location.destroyed?
+      location.create_audit(current_user, Audit::DESTROY_ACTION)
       true
     else
       add_location_errors

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -41,9 +41,7 @@ class LocationForm
     assign_attributes(params)
     if valid?
       run_transaction do
-        if location.save
-          location.create_audit(current_user, Audit::UPDATE_ACTION)
-        end
+        location.create_audit(current_user, Audit::UPDATE_ACTION) if location.save
       end
     else
       false

--- a/app/forms/move_location_form.rb
+++ b/app/forms/move_location_form.rb
@@ -26,6 +26,7 @@ class MoveLocationForm
       # Add an audit record for each of the labwares in the location.
       location_type = parent_location.location_type.name
       child_locations.each do |location|
+        location.create_audit(current_user, "moved to #{location_type}")
         location.labwares.in_batches.each_record do |labware|
           labware.create_audit(current_user, "moved to #{location_type}")
         end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -18,7 +18,7 @@ class Audit < ActiveRecord::Base
     'destroy' => 'Destroyed',
     'Uploaded from manifest' => 'Uploaded from manifest',
     'removed all labwares' => 'Removed all labwares',
-    'update when location emptied' => 'Update when location emptied',
+    'update when location emptied' => 'Update when location emptied'
   }
 
   # auditable actions

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -13,7 +13,13 @@
 class Audit < ActiveRecord::Base
   include Uuidable
 
-  PAST_TENSES = { 'scan' => 'Scanned', 'destroy' => 'Destroyed' }
+  PAST_TENSES = {
+    'scan' => 'Scanned',
+    'destroy' => 'Destroyed',
+    'Uploaded from manifest' => 'Uploaded from manifest',
+    'removed all labwares' => 'Removed all labwares',
+    'update when location emptied' => 'Update when location emptied',
+  }
 
   # auditable actions
   CREATE_ACTION                        = 'create'

--- a/lib/tasks/location_auditable_types_migration.rake
+++ b/lib/tasks/location_auditable_types_migration.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :migration do
+  desc "change historical location auditable_types"
+  task change_location_auditable_types: :environment do |_t|
+    audits = Audit.where(auditable_type: [OrderedLocation.to_s, UnorderedLocation.to_s])
+    num_audits = audits.count
+    puts "Updating #{num_audits} location audits"
+    
+    ActiveRecord::Base.transaction do
+      audits.each do |audit|
+        audit.auditable_type = Location.to_s
+        audit.save!
+        print "."
+      end
+    end
+
+    puts
+    puts "Successfully updated #{num_audits} location audits"
+  end
+end

--- a/lib/tasks/location_auditable_types_migration.rake
+++ b/lib/tasks/location_auditable_types_migration.rake
@@ -6,7 +6,7 @@ namespace :migration do
     audits = Audit.where(auditable_type: [OrderedLocation.to_s, UnorderedLocation.to_s])
     num_audits = audits.count
     puts "Updating #{num_audits} location audits"
-    
+
     ActiveRecord::Base.transaction do
       audits.each do |audit|
         audit.auditable_type = Location.to_s

--- a/spec/forms/location_form_spec.rb
+++ b/spec/forms/location_form_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe LocationForm, type: :model do
     expect(res).to be_truthy
     expect(location_form).to be_valid
     expect(location_form.location).to be_persisted
+
+    audits = Audit.where(auditable_id: location_form.location.id)
+    expect(audits.count).to eq 1
+    expect(audits[0].action).to eq(Audit::CREATE_ACTION)
   end
 
   it "can be edited if exists" do
@@ -44,6 +48,10 @@ RSpec.describe LocationForm, type: :model do
     )
     expect(res).to be_truthy
     expect(location.name).to eq(new_location.name)
+
+    audits = Audit.where(auditable_id: location.id)
+    expect(audits.count).to eq 1
+    expect(audits[0].action).to eq(Audit::UPDATE_ACTION)
   end
 
   it "can be destroyed if it has not been used" do
@@ -53,6 +61,10 @@ RSpec.describe LocationForm, type: :model do
     location_form = LocationForm.new(location)
     res = location_form.destroy(params.merge(user_code: administrator.barcode))
     expect(res).to be_truthy
+    
+    audits = Audit.where(auditable_id: location.id)
+    expect(audits.count).to eq 1
+    expect(audits[0].action).to eq(Audit::DESTROY_ACTION)
   end
 
   it "should create the correct type of location dependent on the attributes" do
@@ -115,6 +127,12 @@ RSpec.describe LocationForm, type: :model do
       expect(res).to be_truthy
       expect(location_form).to be_valid
       expect(Location.find_by(name: 'This is a location with a name with double spaces 1')).to be_present
+      
+      Location.all.map { |l| l.id }.each do |location_id|
+        audits = Audit.where(auditable_id: location_id)
+        expect(audits.count).to eq 1
+        expect(audits[0].action).to eq(Audit::CREATE_ACTION)
+      end
     end
 
     it "should not create multiple locations if start is greater than end" do

--- a/spec/forms/location_form_spec.rb
+++ b/spec/forms/location_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe LocationForm, type: :model do
     location_form = LocationForm.new(location)
     res = location_form.destroy(params.merge(user_code: administrator.barcode))
     expect(res).to be_truthy
-    
+
     audits = Audit.where(auditable_id: location.id)
     expect(audits.count).to eq 1
     expect(audits[0].action).to eq(Audit::DESTROY_ACTION)
@@ -127,8 +127,8 @@ RSpec.describe LocationForm, type: :model do
       expect(res).to be_truthy
       expect(location_form).to be_valid
       expect(Location.find_by(name: 'This is a location with a name with double spaces 1')).to be_present
-      
-      Location.all.map { |l| l.id }.each do |location_id|
+
+      Location.all.map(&:id).each do |location_id|
         audits = Audit.where(auditable_id: location_id)
         expect(audits.count).to eq 1
         expect(audits[0].action).to eq(Audit::CREATE_ACTION)

--- a/spec/forms/move_location_form_spec.rb
+++ b/spec/forms/move_location_form_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe MoveLocationForm, type: :model do
   describe 'audit records' do
     let!(:locations_with_labwares) { create_list(:unordered_location_with_labwares, 5) }
 
+    it "will be added for the child locations" do
+      create_move_location.submit(params.merge(move_location_form:
+        { "parent_location_barcode" => parent_location.barcode, "child_location_barcodes" => child_locations.join_barcodes, "user_code" => user.swipe_card_id }))
+      child_locations.each do |location|
+        location.reload
+        expect(location.audits.first.action).to eq("moved to #{parent_location.location_type.name}")
+      end
+    end
+
     it "will be added for the labwares in the location" do
       create_move_location.submit(params.merge(move_location_form:
         { "parent_location_barcode" => parent_location.barcode, "child_location_barcodes" => locations_with_labwares.join_barcodes, "user_code" => user.swipe_card_id }))


### PR DESCRIPTION
Closes #257 

Changes proposed in this pull request:

* Add create, update and destroy audit entries when performing said actions via the `location_form`
* Update displayed audit entries, specifically improving grammar
* Add a database data migration in the form of a rake task to change all audits with auditable_type `OrderedLocation` or `UnorderedLocation` to instead use `Location`
