### PR TITLE
Removed phantomjs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,6 @@ end
 group :development, :test do
   gem 'byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'factory_bot_rails', '~> 4.8.0'
-  # gem 'phantomjs', require: 'phantomjs/poltergeist' # Headless browser testing
-  # gem 'poltergeist'
   gem 'rails-controller-testing'
   gem 'rb-readline'
   gem 'rspec-rails', '~> 3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -36,16 +36,17 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'capybara-selenium'
   gem 'database_cleaner'
   gem 'mocha'
-  gem 'selenium-webdriver'
+  gem 'webdrivers'
 end
 
 group :development, :test do
   gem 'byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'factory_bot_rails', '~> 4.8.0'
-  gem 'phantomjs', require: 'phantomjs/poltergeist' # Headless browser testing
-  gem 'poltergeist'
+  # gem 'phantomjs', require: 'phantomjs/poltergeist' # Headless browser testing
+  # gem 'poltergeist'
   gem 'rails-controller-testing'
   gem 'rb-readline'
   gem 'rspec-rails', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,12 +83,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
     case_transform (0.2)
       activesupport
     celluloid (0.16.0)
       timers (~> 4.0.0)
     childprocess (3.0.0)
-    cliver (0.3.2)
     codemirror-rails (5.16.0)
       railties (>= 3.0, < 6.0)
     coderay (1.1.2)
@@ -196,11 +198,6 @@ GEM
     parallel (1.19.2)
     parser (2.7.1.5)
       ast (~> 2.4.1)
-    phantomjs (2.1.1.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -352,6 +349,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.4.2)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket (1.2.8)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
@@ -372,6 +373,7 @@ DEPENDENCIES
   bunny
   byebug
   capybara
+  capybara-selenium
   codemirror-rails
   coffee-rails (~> 4.2.0)
   database_cleaner
@@ -385,9 +387,7 @@ DEPENDENCIES
   mini_racer
   mocha
   mysql2
-  phantomjs
   pmb-client (= 0.1.0)!
-  poltergeist
   pry
   puma
   rack-cors
@@ -401,13 +401,13 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   select2-rails
-  selenium-webdriver
   spring (~> 1.3.6)
   teaspoon-jasmine
   travis
   turbolinks
   uglifier (>= 1.3.0)
   web-console
+  webdrivers
   with_model
 
 BUNDLED WITH

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_084153) do
+ActiveRecord::Schema.define(version: 2020_09_23_085334) do
 
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "auditable_type"
@@ -24,12 +24,6 @@ ActiveRecord::Schema.define(version: 2020_11_16_084153) do
     t.index ["auditable_id", "auditable_type"], name: "index_audits_on_auditable_id_and_auditable_type"
     t.index ["auditable_type"], name: "index_audits_on_auditable_type"
     t.index ["user_id"], name: "index_audits_on_user_id"
-  end
-
-  create_table "barcodes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "prefix"
-    t.integer "counter"
-    t.index ["counter"], name: "index_barcodes_on_counter"
   end
 
   create_table "coordinates", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_085334) do
+ActiveRecord::Schema.define(version: 2020_11_16_084153) do
 
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "auditable_type"
@@ -24,6 +24,12 @@ ActiveRecord::Schema.define(version: 2020_09_23_085334) do
     t.index ["auditable_id", "auditable_type"], name: "index_audits_on_auditable_id_and_auditable_type"
     t.index ["auditable_type"], name: "index_audits_on_auditable_type"
     t.index ["user_id"], name: "index_audits_on_user_id"
+  end
+
+  create_table "barcodes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "prefix"
+    t.integer "counter"
+    t.index ["counter"], name: "index_barcodes_on_counter"
   end
 
   create_table "coordinates", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/spec/features/scans_spec.rb
+++ b/spec/features/scans_spec.rb
@@ -145,15 +145,19 @@ RSpec.describe "Scans", type: :feature do
   end
 end
 
+# This is necessary as the labware barcodes textarea is not visible
 def fill_in_labware_barcodes(text)
   within ".CodeMirror" do
     # Click makes CodeMirror element active:
     current_scope.click
-
+  
     # Find the hidden textarea:
     field = current_scope.find("textarea", visible: false)
-
+  
     # Mimic user typing the text:
     field.send_keys text
   end
 end
+
+
+

--- a/spec/features/scans_spec.rb
+++ b/spec/features/scans_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Scans", type: :feature do
     fill_in "User swipe card id/barcode", with: user.swipe_card_id
     fill_in "Location barcode", with: location.barcode
     expect(page.all('.CodeMirror-linenumber').count).to eq(1)
-    page.find('.scanArea').send_keys(labwares.join_barcodes)
+    fill_in_labware_barcodes(labwares.join_barcodes)
     expect(page.all('.CodeMirror-linenumber').count).to eq(34)
   end
 
@@ -37,13 +37,13 @@ RSpec.describe "Scans", type: :feature do
     fill_in "User swipe card id/barcode", with: user.swipe_card_id
     fill_in "Location barcode", with: location.barcode
     expect(page.all('.cm-error').count).to eq(0)
-    page.find('.scanArea').send_keys("1234\n")
+    fill_in_labware_barcodes("1234\n")
     expect(page.all('.cm-error').count).to eq(0)
-    page.find('.scanArea').send_keys("4567\n")
+    fill_in_labware_barcodes("4567\n")
     expect(page.all('.cm-error').count).to eq(0)
-    page.find('.scanArea').send_keys("1234\n")
+    fill_in_labware_barcodes("1234\n")
     expect(page.all('.cm-error').count).to eq(1)
-    page.find('.scanArea').send_keys("4567\n")
+    fill_in_labware_barcodes("4567\n")
     expect(page.all('.cm-error').count).to eq(2)
   end
 
@@ -142,5 +142,18 @@ RSpec.describe "Scans", type: :feature do
 
       expect(page).to have_content("errors prohibited this record from being saved")
     end
+  end
+end
+
+def fill_in_labware_barcodes(text)
+  within ".CodeMirror" do
+    # Click makes CodeMirror element active:
+    current_scope.click
+
+    # Find the hidden textarea:
+    field = current_scope.find("textarea", visible: false)
+
+    # Mimic user typing the text:
+    field.send_keys text
   end
 end

--- a/spec/features/scans_spec.rb
+++ b/spec/features/scans_spec.rb
@@ -150,14 +150,11 @@ def fill_in_labware_barcodes(text)
   within ".CodeMirror" do
     # Click makes CodeMirror element active:
     current_scope.click
-  
+
     # Find the hidden textarea:
     field = current_scope.find("textarea", visible: false)
-  
+
     # Mimic user typing the text:
     field.send_keys text
   end
 end
-
-
-

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,8 @@ require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'with_model'
-require 'capybara/poltergeist'
+require 'webdrivers/chromedriver'
+require 'selenium/webdriver'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -53,8 +54,6 @@ RSpec.configure do |config|
 
   config.extend WithModel
 
-  Capybara.javascript_driver = :poltergeist
-
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
@@ -89,4 +88,30 @@ RSpec.configure do |config|
   Capybara.add_selector(:data_output) do
     xpath { |id| XPath.css("[data-output='#{id}']") }
   end
+
+  Capybara.register_driver :headless_chrome do |app|
+    driver = Capybara.drivers[:selenium_chrome_headless].call(app)
+
+    configure_window_size(driver)
+    enable_chrome_headless_downloads(driver)
+  end
+
+  def configure_window_size(driver)
+    # links in header disappear if window is too small, then capybara can't click on them
+    driver.options[:options].add_argument('--window-size=1600,3200')
+  end
+
+  def enable_chrome_headless_downloads(driver)
+    driver.options[:options].add_preference(:download, default_directory: Capybara.save_path)
+    driver.browser.download_path = Capybara.save_path
+    driver
+  end
+
+  Capybara.register_driver :chrome do |app|
+    options = Selenium::WebDriver::Chrome::Options.new
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  end
+
+  Capybara.default_max_wait_time = 10
+  Capybara.javascript_driver = ENV.fetch('JS_DRIVER', 'headless_chrome').to_sym
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,22 +89,9 @@ RSpec.configure do |config|
     xpath { |id| XPath.css("[data-output='#{id}']") }
   end
 
+  # copied from Sequencescape but removed the extra bits not needed currently.
   Capybara.register_driver :headless_chrome do |app|
-    driver = Capybara.drivers[:selenium_chrome_headless].call(app)
-
-    configure_window_size(driver)
-    enable_chrome_headless_downloads(driver)
-  end
-
-  def configure_window_size(driver)
-    # links in header disappear if window is too small, then capybara can't click on them
-    driver.options[:options].add_argument('--window-size=1600,3200')
-  end
-
-  def enable_chrome_headless_downloads(driver)
-    driver.options[:options].add_preference(:download, default_directory: Capybara.save_path)
-    driver.browser.download_path = Capybara.save_path
-    driver
+    Capybara.drivers[:selenium_chrome_headless].call(app)
   end
 
   Capybara.register_driver :chrome do |app|
@@ -113,5 +100,5 @@ RSpec.configure do |config|
   end
 
   Capybara.default_max_wait_time = 10
-  Capybara.javascript_driver = ENV.fetch('JS_DRIVER', 'headless_chrome').to_sym
+  Capybara.javascript_driver = :headless_chrome
 end


### PR DESCRIPTION
Phantomjs was deprecated a couple of years ago in favour of selenium webdriver. This is technical debt. Although it is only causing warnings could cause issues for new developers and could break at any time and halt development. I thought the risk was too high to leave it there.