### PR TITLE
GPL-787 Added check to labware barcodes for csv upload

### DIFF
--- a/app/models/manifest_uploader.rb
+++ b/app/models/manifest_uploader.rb
@@ -22,7 +22,7 @@ class ManifestUploader
   end
 
   def labwares
-    @labwares ||= data.collect(&:last).uniq
+    @labwares ||= data.collect { |row| row.second }.uniq
   end
 
   def run
@@ -86,7 +86,8 @@ class ManifestUploader
   end
 
   def check_if_any_labwares_are_locations
-    if labwares.compact.any? { |labware| labware.match(/^#{Location::BARCODE_PREFIX}?/o) }
+    return unless errors.blank?
+    if labwares.any? { |labware| labware.match(/^#{Location::BARCODE_PREFIX}?/o) }
       errors.add(:base, "Labware barcodes cannot be the same as an existing location barcode. Please review and remove incorrect labware barcodes")
     end
   end

--- a/app/models/manifest_uploader.rb
+++ b/app/models/manifest_uploader.rb
@@ -22,7 +22,7 @@ class ManifestUploader
   end
 
   def labwares
-    @labwares ||= data.collect { |row| row.second }.uniq
+    @labwares ||= data.collect(&:second).uniq
   end
 
   def run
@@ -86,7 +86,8 @@ class ManifestUploader
   end
 
   def check_if_any_labwares_are_locations
-    return unless errors.blank?
+    return if errors.present?
+
     if labwares.any? { |labware| labware.match(/^#{Location::BARCODE_PREFIX}?/o) }
       errors.add(:base, "Labware barcodes cannot be the same as an existing location barcode. Please review and remove incorrect labware barcodes")
     end

--- a/spec/models/manifest_uploader_spec.rb
+++ b/spec/models/manifest_uploader_spec.rb
@@ -137,6 +137,22 @@ RSpec.describe ManifestUploader, type: :model do
         expect(manifest_uploader.errors.full_messages).to eq(["It looks like there is some missing or invalid data. Please review and remove anything that shouldn't be there."])
       end
     end
+
+    context 'when there are labwares with the same barcode as an existing location' do
+      before(:each) do
+        manifest.concat("#{unordered_location.barcode},#{unordered_location.barcode}\n")
+        manifest_uploader.file = manifest
+      end
+
+      it 'will not be valid' do
+        expect(manifest_uploader).to_not be_valid
+      end
+
+      it 'will only show one error' do
+        manifest_uploader.run
+        expect(manifest_uploader.errors.full_messages).to eq(["Labware barcodes cannot be the same as an existing location barcode. Please review and remove incorrect labware barcodes"])
+      end
+    end
   end
 
   context 'when the data is valid' do


### PR DESCRIPTION
Closes #270 

Changes proposed in this pull request:

* Upload labwhere csv now has a check to make sure there are no labwares with the same barcode as an existing location
*

Comment: I believe the issue on #270  involving scan in/out having the same error as the one solved in this PR has previously been resolved
