### PR TITLE
Fix remove whitespace scan in

### DIFF
--- a/app/forms/scan_form.rb
+++ b/app/forms/scan_form.rb
@@ -12,7 +12,7 @@ class ScanForm
   set_form_variables :labware_barcodes, :location_barcode, :start_position, location: :find_location
 
   after_validate do
-    scan.add_attributes_from_collection(LabwareCollection.open(location: location, user: current_user, coordinates: available_coordinates, labwares: labware_barcodes).push)
+    scan.add_attributes_from_collection(LabwareCollection.open(location: location, user: current_user, coordinates: available_coordinates, labwares: labwares).push)
     scan.save
   end
 
@@ -38,7 +38,7 @@ class ScanForm
   end
 
   def labwares
-    @labwares ||= labware_barcodes.split("\n")
+    @labwares ||= labware_barcodes.split("\n").collect(&:strip)
   end
 
   def check_if_any_barcodes_are_locations

--- a/app/lib/utils/barcode_utilities.rb
+++ b/app/lib/utils/barcode_utilities.rb
@@ -4,6 +4,11 @@ module BarcodeUtilities
   ##
   # Take the barcodes for the object and create a string using the defined delimiter.
   def join_barcodes(char = "\n")
-    self.collect { |l| l.barcode }.join(char)
+    extract_barcodes().join(char)
+  end
+
+  # Extract the barcodes from the input object(s)
+  def extract_barcodes
+    self.collect { |l| l.barcode }
   end
 end

--- a/app/lib/utils/barcode_utilities.rb
+++ b/app/lib/utils/barcode_utilities.rb
@@ -4,7 +4,7 @@ module BarcodeUtilities
   ##
   # Take the barcodes for the object and create a string using the defined delimiter.
   def join_barcodes(char = "\n")
-    extract_barcodes().join(char)
+    extract_barcodes.join(char)
   end
 
   # Extract the barcodes from the input object(s)

--- a/app/models/labware_collection/base.rb
+++ b/app/models/labware_collection/base.rb
@@ -37,7 +37,7 @@ module LabwareCollection
     end
 
     def labwares=(labwares) # rubocop:todo Lint/DuplicateMethods
-      @labwares = labwares.split("\n").uniq
+      @labwares = labwares.uniq
     end
 
     private

--- a/spec/factories/labware_collections.rb
+++ b/spec/factories/labware_collections.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :labware_collection_unordered_location, class: LabwareCollection::UnorderedLocation do
     location { FactoryBot.create(:location_with_parent) }
     user { FactoryBot.create(:administrator) }
-    labwares { (FactoryBot.build_list(:labware, 3) + FactoryBot.create_list(:labware_with_location, 2)).join_barcodes }
+    labwares { (FactoryBot.build_list(:labware, 3) + FactoryBot.create_list(:labware_with_location, 2)).extract_barcodes }
 
     initialize_with { new(location: location, user: user, labwares: labwares) }
 

--- a/spec/models/labware_collection_spec.rb
+++ b/spec/models/labware_collection_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe LabwareCollection, type: :model do
 
   describe 'adding to an unordered location' do
     let!(:location)           { create(:location_with_parent) }
-    let(:labware_collection)  { LabwareCollection.open(location: location, user: user, labwares: labwares.join_barcodes) }
+    let(:labware_collection)  { LabwareCollection.open(location: location, user: user, labwares: labwares.extract_barcodes) }
 
     it "creates the correct number of labwares" do
       expect(labware_collection.count).to eq(labwares.count)
@@ -37,7 +37,7 @@ RSpec.describe LabwareCollection, type: :model do
     end
 
     it 'removes duplicates from labwares which have been passed' do
-      labware_collection = LabwareCollection.open(location: location, user: user, labwares: new_labwares.join_barcodes << "\n" << new_labwares.join_barcodes)
+      labware_collection = LabwareCollection.open(location: location, user: user, labwares: new_labwares.extract_barcodes + new_labwares.extract_barcodes)
       expect(labware_collection.count).to eq(new_labwares.count)
       labware_collection.push
       expect(location.labwares.count).to eq(new_labwares.count)
@@ -48,7 +48,7 @@ RSpec.describe LabwareCollection, type: :model do
     let!(:location) { create(:ordered_location_with_parent, rows: 5, columns: 5) }
 
     it "adds labwares to the correct coordinates if a starting position is added" do
-      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.join_barcodes, start_position: 5)
+      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.extract_barcodes, start_position: 5)
       labware_collection.push
       expect(location.labwares.count).to eq(labware_collection.count)
       ((labware_collection.start_position)..(labware_collection.start_position + labware_collection.count - 1)).each do |i|
@@ -58,14 +58,14 @@ RSpec.describe LabwareCollection, type: :model do
 
     it "allows coordinates to be passed" do
       coordinates = location.available_coordinates(5, labwares.count)
-      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.join_barcodes, coordinates: coordinates)
+      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.extract_barcodes, coordinates: coordinates)
       labware_collection.push
       expect(location.labwares.count).to eq(labware_collection.count)
     end
 
     it "adds labwares to the correct coordinates if some of the coordinates are already filled" do
       location.coordinates.find_by_position(position: 6).fill(create(:labware))
-      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.join_barcodes, start_position: 5)
+      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.extract_barcodes, start_position: 5)
       labware_collection.push
       expect(location.labwares.count).to eq(labware_collection.count + 1)
       ((labware_collection.start_position)..(labware_collection.start_position + labware_collection.count)).each do |i|
@@ -74,14 +74,14 @@ RSpec.describe LabwareCollection, type: :model do
     end
 
     it "fails if the position runs over the end of the available coordinates" do
-      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.join_barcodes, start_position: 20)
+      labware_collection = LabwareCollection.open(location: location, user: user, labwares: labwares.extract_barcodes, start_position: 20)
       expect(labware_collection).to_not be_valid
       labware_collection.push
       expect(location.labwares).to be_empty
     end
 
     it 'removes duplicates from labwares which have been passed' do
-      labware_collection = LabwareCollection.open(location: location, user: user, labwares: new_labwares.join_barcodes << "\n" << new_labwares.join_barcodes, start_position: 5)
+      labware_collection = LabwareCollection.open(location: location, user: user, labwares: new_labwares.extract_barcodes + new_labwares.extract_barcodes, start_position: 5)
       expect(labware_collection.count).to eq(new_labwares.count)
       labware_collection.push
       ((labware_collection.start_position)..(labware_collection.start_position + labware_collection.count - 1)).each do |i|


### PR DESCRIPTION
Closes #293 

Changes proposed in this pull request:

* Update the LabwareCollection base class to expect a list of labware barcodes on initialisation, rather than a string of newline separated labware barcodes
* Strip whitespace from scanned in labware barcodes
