### PR TITLE
GPL-797 changed audit trail for moving locations

### DIFF
--- a/app/forms/move_location_form.rb
+++ b/app/forms/move_location_form.rb
@@ -85,11 +85,11 @@ class MoveLocationForm
   def create_audits
     # Add an audit record for each child location, and labwares in each child location
     parent_location.children = child_locations
-    location_type = parent_location.location_type.name
+    location_name = parent_location.name
     child_locations.each do |location|
-      location.create_audit(current_user, "moved to #{location_type}")
+      location.create_audit(current_user, "moved to #{location_name}")
       location.labwares.in_batches.each_record do |labware|
-        labware.create_audit(current_user, "moved to #{location_type}")
+        labware.create_audit(current_user, "moved to #{location_name}")
       end
     end
   end

--- a/spec/forms/move_location_form_spec.rb
+++ b/spec/forms/move_location_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe MoveLocationForm, type: :model do
         { "parent_location_barcode" => parent_location.barcode, "child_location_barcodes" => child_locations.join_barcodes, "user_code" => user.swipe_card_id }))
       child_locations.each do |location|
         location.reload
-        expect(location.audits.first.action).to eq("moved to #{parent_location.location_type.name}")
+        expect(location.audits.first.action).to eq("moved to #{parent_location.name}")
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe MoveLocationForm, type: :model do
       locations_with_labwares.each do |location|
         location.reload
         expect(location.labwares.all? { |labware| labware.audits.count == 1 }).to be_truthy
-        expect(location.labwares.first.audits.first.action).to eq("moved to #{parent_location.location_type.name}")
+        expect(location.labwares.first.audits.first.action).to eq("moved to #{parent_location.name}")
       end
     end
   end
@@ -85,7 +85,7 @@ RSpec.describe MoveLocationForm, type: :model do
 
       location.reload
       expect(location.labwares.all? { |labware| labware.audits.count == 1 }).to be_truthy
-      expect(location.audits.first.action).to eq("moved to #{parent_location.location_type.name}")
+      expect(location.audits.first.action).to eq("moved to #{parent_location.name}")
     end
   end
 end


### PR DESCRIPTION
Audit trail for moving locations now shows location name instead of location type
Changes proposed in this pull request:

*
*
* ...
