### PR TITLE
BUG fix - shifted drop down position to account for new link in nav bar

### DIFF
--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -86,7 +86,7 @@ nav{
       }
       ul{
         position: absolute;
-        left: 590px;
+        left: 750px;
         @include rounded-corners(5px);
         @include drop-shadow(2px, gray);
         opacity: 0.9;


### PR DESCRIPTION
Adding a new link 'find locations' meant that the configure link drop down was in the incorrect place, this PR moves the drop down back under configure