### PR TITLE
DPL-311 destroy location

### DIFF
--- a/app/controllers/api/locations_controller.rb
+++ b/app/controllers/api/locations_controller.rb
@@ -27,7 +27,7 @@ class Api::LocationsController < ApiController
   # For example, to get information about a location with barcode 'lw-location-1-1', the URL would be:
   # GET /api/locations/info?barcode=lw-location-1-1
   #
-  # @return A response with a JSON body. If a location is found, the body contains the labwares 
+  # @return A response with a JSON body. If a location is found, the body contains the labwares
   # and the maximum descendant depth.
   #  e.g { labwares: [labware1, labware2], depth: 2 }
   #  If no location is found, the body contains an error. e.g { errors: ['Location not found'] }

--- a/app/controllers/api/locations_controller.rb
+++ b/app/controllers/api/locations_controller.rb
@@ -22,6 +22,25 @@ class Api::LocationsController < ApiController
     process_location(@location.update(permitted_params))
   end
 
+  # Retrieves information about a location based on its barcode.
+  # @param params The request parameters. Expected to contain a `:barcode` key with the barcode of the location.
+  # For example, to get information about a location with barcode 'lw-location-1-1', the URL would be:
+  # GET /api/locations/info?barcode=lw-location-1-1
+  #
+  # @return A response with a JSON body. If a location is found, the body contains the labwares 
+  # and the maximum descendant depth.
+  #  e.g { labwares: [labware1, labware2], depth: 2 }
+  #  If no location is found, the body contains an error. e.g { errors: ['Location not found'] }
+
+  def info
+    location = Location.find_by(barcode: params[:barcode])
+    if location
+      render json: { labwares: location.labwares.to_a, depth: location.max_descendant_depth }
+    else
+      render json: { errors: ['Location not found'] }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def current_resource

--- a/app/models/locations/location.rb
+++ b/app/models/locations/location.rb
@@ -188,6 +188,17 @@ class Location < ApplicationRecord
     parentage
   end
 
+  # Calculates the maximum depth of the descendant locations of the current location.
+  # The depth of a location is defined as the number of child locations below it.
+  # This method works by recursively calling `max_descendant_depth` (of ancestry gem) on all children of the current location,
+  # finding the maximum of these values, and adding 1 to it.
+  # If the location has no children, the depth is 0.
+  #
+  # @return [Integer] The maximum depth of the descendants of the current location
+  def max_descendant_depth
+    (children.map(&:max_descendant_depth).max || -1) + 1
+  end
+
   private
 
   ##

--- a/app/models/locations/location.rb
+++ b/app/models/locations/location.rb
@@ -190,8 +190,8 @@ class Location < ApplicationRecord
 
   # Calculates the maximum depth of the descendant locations of the current location.
   # The depth of a location is defined as the number of child locations below it.
-  # This method works by recursively calling `max_descendant_depth` (of ancestry gem) on all children of the current location,
-  # finding the maximum of these values, and adding 1 to it.
+  # This method works by recursively calling max_descendant_depth (of ancestry gem)
+  # on all children of the current location, finding the maximum of these values.
   # If the location has no children, the depth is 0.
   #
   # @return [Integer] The maximum depth of the descendants of the current location

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,9 +65,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     get 'docs', to: 'docs#index'
+    get 'locations/info', to: 'locations#info'
     post 'labwares/searches', to: 'labwares/searches#create'
     post 'labwares/locations', to: 'labwares/locations#create'
-
+ 
     # This needs to be a post due to the number of barcodes that will be passed which is not possible with a get
     post 'labwares_by_barcode', to: 'labwares#by_barcode'
     root 'docs#index'

--- a/spec/controllers/locations_info_controller_spec.rb
+++ b/spec/controllers/locations_info_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::LocationsController, type: :controller do
@@ -23,7 +25,7 @@ RSpec.describe Api::LocationsController, type: :controller do
 
       it 'returns an error' do
         expect(response.body).to eq({ errors: ['Location not found'] }.to_json)
-        expect(response.status).to eq(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/controllers/locations_info_controller_spec.rb
+++ b/spec/controllers/locations_info_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Api::LocationsController, type: :controller do
+  describe '#info' do
+    let(:location) { create(:location) }
+
+    context 'when location exists' do
+      before do
+        allow(Location).to receive(:find_by).with(barcode: location.barcode).and_return(location)
+        get :info, params: { barcode: location.barcode }
+      end
+
+      it 'returns the location info' do
+        expect(response.body).to eq({ labwares: location.labwares.to_a, depth: location.max_descendant_depth }.to_json)
+      end
+    end
+
+    context 'when location does not exist' do
+      before do
+        allow(Location).to receive(:find_by).with(barcode: 'nonexistent').and_return(nil)
+        get :info, params: { barcode: 'nonexistent' }
+      end
+
+      it 'returns an error' do
+        expect(response.body).to eq({ errors: ['Location not found'] }.to_json)
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/models/locations/location_spec.rb
+++ b/spec/models/locations/location_spec.rb
@@ -466,4 +466,15 @@ RSpec.describe Location, type: :model do
       expect(audit.message).to eq("#{update_action.display_text} and stored in #{location.breadcrumbs}")
     end
   end
+
+  describe '#max_descendant_depth' do
+    it 'returns all labwares in the location and its children' do
+      location1 = create(:location, name: 'Location1')
+      location2 = create(:location, name: 'Location2', parent: location1)
+      location3 = create(:location, name: 'Location3', parent: location2)
+      expect(location1.max_descendant_depth).to eq(2)
+      expect(location2.max_descendant_depth).to eq(1)
+      expect(location3.max_descendant_depth).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Closes [#340](https://github.com/sanger/asset_audits/issues/340)

#### Changes proposed in this pull request
Added a new endpoint to get location information. This endpoint returns all labware inside the location and the depth of its descendants.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
