### PR TITLE
Y24-435 - Shared check release version

### DIFF
--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -7,21 +7,5 @@ on:
       - master
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get specific changed files
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            .release-version
-          
-      - name: Run step looking for change in the release version
-        run: >-
-          if ! "${{ steps.changed-files-specific.outputs.any_changed }}"; then
-            echo "Please change the release version number"
-            exit 1;
-          fi
+  check-release-version:
+    uses: sanger/.github/.github/workflows/check-release-version.yml@master


### PR DESCRIPTION
#### Changes proposed in this pull request

- Removes tj-actions/changed-files due to security issues.
- Replaces check release version with reusable worfklow.

Part of: https://github.com/sanger/General-Backlog-Items/issues/464