### PR TITLE
DPL-214 Labware - Modified event old audit method

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,12 +20,17 @@ class Event
   # It affects how much data we send in the event - whether we expect it to still be relevant
   def for_old_audit?
     # The labware record shouldn't be missing, but if it is, treat this as an 'old' audit
-    @for_old_audit ||= labware.blank? || audit.id != labware.audits.last.id
-  # TODO: uncertain what is triggering the NoMethodError exceptions here, so added a rescue to provide more context
-  rescue NoMethodError => e
-    raise NoMethodError,
-          "Error in Event#for_old_audit?: labware barcode=#{labware&.barcode}, " \
-          "audit id=#{audit&.id}. Original error: #{e.message}"
+    # And also if the audit id does not match the labware's last audit id (when it has a previous audit)
+    @for_old_audit ||= if labware.blank?
+                         true
+                       else
+                         last_audit_id = labware.audits&.last&.id
+                         if last_audit_id.blank?
+                           false
+                         else
+                           audit.id != last_audit_id
+                         end
+                       end
   end
 
   def location
@@ -69,7 +74,7 @@ class Event
     @coordinate ||= unless for_old_audit?
                       # if we are firing an event for a newly created audit,
                       # we can grab the current coordinate from the labware
-                      labware.coordinate
+                      labware&.coordinate
                     end
     # otherwise, return nil as we're re-firing an old event & don't know the coordinate for the time it occurred
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -196,7 +196,6 @@ RSpec.describe Event, type: :model do
     end
 
     context 'where the labware exists but has no audits' do
-      # let!(:labware_barcode) { labware.barcode }
       let(:labware_without_audits) { create(:labware_with_location) }
       let(:audit) { create(:audit_of_labware, labware: labware_without_audits) }
       let(:attributes) { { labware: labware_without_audits, audit: audit } }
@@ -211,18 +210,18 @@ RSpec.describe Event, type: :model do
         }
       end
 
-      let(:expected_nomethod_message) do
-        "Error in Event#for_old_audit?: labware barcode=#{labware_without_audits&.barcode}, " \
-          "audit id=#{audit&.id.inspect}. Original error: undefined method 'id' for nil"
-      end
+      # let(:expected_nomethod_message) do
+      #   "Error in Event#for_old_audit?: labware barcode=#{labware_without_audits&.barcode}, " \
+      #     "audit id=#{audit&.id.inspect}. Original error: undefined method 'id' for nil"
+      # end
 
       before do
         # Remove all audits from the labware
         labware_without_audits.audits.destroy_all
       end
 
-      it 'throws a NoMethodError when trying to access the last audit' do
-        expect { event.for_old_audit? }.to raise_error(NoMethodError, expected_nomethod_message)
+      it 'treats it as a new audit' do
+        expect(event.for_old_audit?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
To more clearly handle scenario where labware exists but does not have a previous audit
