### PR TITLE
DPL-214 Labware - fix labwares list and audit creation

### DIFF
--- a/app/forms/auditor.rb
+++ b/app/forms/auditor.rb
@@ -9,6 +9,6 @@ module Auditor
   end
 
   def create_audit
-    model.create_audit(current_user)
+    model.create_audit!(current_user)
   end
 end

--- a/app/forms/coordinates_form.rb
+++ b/app/forms/coordinates_form.rb
@@ -22,7 +22,7 @@ class CoordinatesForm
         Coordinate.update(coordinate_ids, update_params)
 
         coordinates.each do |coordinate|
-          coordinate.create_audit(current_user, AuditAction::UPDATE)
+          coordinate.create_audit!(current_user, AuditAction::UPDATE)
         end
       end
       true

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -29,7 +29,7 @@ class LocationForm
           @location = new_location
           check_location
           @location.save!
-          @location.create_audit(current_user, AuditAction::CREATE)
+          @location.create_audit!(current_user, AuditAction::CREATE)
         end
       end
     else
@@ -42,7 +42,7 @@ class LocationForm
     assign_attributes(params)
     if valid?
       run_transaction do
-        location.create_audit(current_user, AuditAction::UPDATE) if location.save
+        location.create_audit!(current_user, AuditAction::UPDATE) if location.save
       end
     else
       false
@@ -57,7 +57,7 @@ class LocationForm
 
     location.destroy
     if location.destroyed?
-      location.create_audit(current_user, AuditAction::DESTROY)
+      location.create_audit!(current_user, AuditAction::DESTROY)
       true
     else
       add_location_errors

--- a/app/forms/move_location_form.rb
+++ b/app/forms/move_location_form.rb
@@ -93,9 +93,9 @@ class MoveLocationForm
     parent_location.children = child_locations
     location_type = parent_location.location_type.name
     child_locations.each do |location|
-      location.create_audit(current_user, "moved to #{location_type}")
+      location.create_audit!(current_user, "moved to #{location_type}")
       location.labwares.in_batches.each_record do |labware|
-        labware.create_audit(current_user, "moved to #{location_type}")
+        labware.create_audit!(current_user, "moved to #{location_type}")
       end
     end
   end

--- a/app/forms/scan_form.rb
+++ b/app/forms/scan_form.rb
@@ -41,7 +41,8 @@ class ScanForm
   end
 
   def labwares
-    @labwares ||= labware_barcodes.split("\n").uniq.collect(&:strip)
+    # split on new lines, and remove duplicate barcodes and blank lines
+    @labwares ||= labware_barcodes.split("\n").uniq.collect(&:strip).compact_blank
   end
 
   def check_if_any_barcodes_are_locations

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -31,7 +31,7 @@ class UserForm
       user.update(@params[:user].permit(:swipe_card_id, :barcode, :status, :team_id, :type, :login))
       raise ActiveRecord::Rollback unless valid?
 
-      user.create_audit(current_user)
+      user.create_audit!(current_user)
       true
     end
   end

--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -14,17 +14,8 @@ module Auditable
   ##
   # Build and save an associated audit record.
   # The record data will be a json representation of the saved object.
-  def create_audit(user, action = nil)
-    create_audit_shared(user, action, false)
-  end
-
   def create_audit!(user, action = nil)
-    create_audit_shared(user, action, true)
-  end
-
-  def create_audit_shared(user, action, throw_exception)
-    create_method = throw_exception ? :create! : :create
-    my_audit = Audit.send(create_method, user: user, action: action, record_data: self, auditable: self)
+    my_audit = Audit.send(:create!, user: user, action: action, record_data: self, auditable: self)
     write_event(my_audit) if respond_to?(:write_event)
     my_audit
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,8 +15,7 @@ class Event
 
   delegate :uuid, to: :audit
 
-  # Are we firing an event for a newly created audit,
-  # or re-firing an event for an 'old' audit?
+  # Are we firing an event for a newly created audit, or re-firing an event for an 'old' audit?
   # It affects how much data we send in the event - whether we expect it to still be relevant
   def for_old_audit?
     # The labware record shouldn't be missing, but if it is, treat this as an 'old' audit

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,12 +20,17 @@ class Event
   # It affects how much data we send in the event - whether we expect it to still be relevant
   def for_old_audit?
     # The labware record shouldn't be missing, but if it is, treat this as an 'old' audit
-    @for_old_audit ||= labware.blank? || audit.id != labware.audits.last.id
-  # TODO: uncertain what is triggering the NoMethodError exceptions here, so added a rescue to provide more context
-  rescue NoMethodError => e
-    raise NoMethodError,
-          "Error in Event#for_old_audit?: labware barcode=#{labware&.barcode}, " \
-          "audit id=#{audit&.id}. Original error: #{e.message}"
+    # And also if the audit id does not match the labware's last audit id (when it has a previous audit)
+    @for_old_audit ||= if labware.blank?
+                         true
+                       else
+                         last_audit_id = labware.audits&.last&.id
+                         if last_audit_id.blank?
+                           false
+                         else
+                           audit.id != last_audit_id
+                         end
+                       end
   end
 
   def location
@@ -69,7 +74,7 @@ class Event
     @coordinate ||= unless for_old_audit?
                       # if we are firing an event for a newly created audit,
                       # we can grab the current coordinate from the labware
-                      labware.coordinate
+                      labware&.coordinate
                     end
     # otherwise, return nil as we're re-firing an old event & don't know the coordinate for the time it occurred
   end

--- a/app/models/labware_collection/labware_collection/base.rb
+++ b/app/models/labware_collection/labware_collection/base.rb
@@ -23,7 +23,7 @@ module LabwareCollection
             model = find_labware(labware)
             add_original_location(model)
             yield(model, i) if block_given?
-            model.create_audit(user)
+            model.create_audit!(user)
           end
         end
       end

--- a/app/models/locations/location.rb
+++ b/app/models/locations/location.rb
@@ -167,7 +167,7 @@ class Location < ApplicationRecord
     return if has_child_locations?
 
     # audit that user emptied the location
-    create_audit(current_user, AuditAction::REMOVE_ALL_LABWARES)
+    create_audit!(current_user, AuditAction::REMOVE_ALL_LABWARES)
 
     unknown_location = UnknownLocation.get
 
@@ -175,7 +175,7 @@ class Location < ApplicationRecord
     labwares.find_each do |labware|
       labware.update(location: unknown_location, coordinate: nil)
       # audit that each labware is now in an unknown location
-      labware.create_audit(current_user, AuditAction::EMPTY_LOCATION)
+      labware.create_audit!(current_user, AuditAction::EMPTY_LOCATION)
     end
 
     # Reset the association to ensure it is no-longer populated

--- a/spec/models/concerns/auditable_spec.rb
+++ b/spec/models/concerns/auditable_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Auditable, type: :model do
   let!(:location_with_parent) { create(:location_with_parent, parent: parent_location) }
 
   it 'should be able to create an audit record' do
-    location.create_audit(user, AuditAction::CREATE)
+    location.create_audit!(user, AuditAction::CREATE)
     audit = location.audits.first
     expect(audit.user).to eq(user)
     expect(audit.record_data.except('created_at',
@@ -23,20 +23,20 @@ RSpec.describe Auditable, type: :model do
   end
 
   it 'should add an action if none is provided' do
-    location.create_audit(user)
+    location.create_audit!(user)
     expect(location.audits.last.action).to eq(AuditAction::CREATE)
     # Need to put the created date into the past because the test is too quick,
     # so that created date and updated date are equal
     location.update(created_at: DateTime.now - 1)
     location.update(name: 'New Name')
-    location.create_audit(user)
+    location.create_audit!(user)
     expect(location.audits.last.action).to eq(AuditAction::UPDATE)
   end
 
   context 'without write event method' do
     it 'does not write an event when creating an audit' do
       expect(Messages).not_to receive(:publish)
-      location.create_audit(user)
+      location.create_audit!(user)
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe Auditable, type: :model do
 
     it 'writes an event when creating an audit' do
       expect(Messages).to receive(:publish)
-      model_instance.create_audit(user)
+      model_instance.create_audit!(user)
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -210,11 +210,6 @@ RSpec.describe Event, type: :model do
         }
       end
 
-      # let(:expected_nomethod_message) do
-      #   "Error in Event#for_old_audit?: labware barcode=#{labware_without_audits&.barcode}, " \
-      #     "audit id=#{audit&.id.inspect}. Original error: undefined method 'id' for nil"
-      # end
-
       before do
         # Remove all audits from the labware
         labware_without_audits.audits.destroy_all

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -196,7 +196,6 @@ RSpec.describe Event, type: :model do
     end
 
     context 'where the labware exists but has no audits' do
-      # let!(:labware_barcode) { labware.barcode }
       let(:labware_without_audits) { create(:labware_with_location) }
       let(:audit) { create(:audit_of_labware, labware: labware_without_audits) }
       let(:attributes) { { labware: labware_without_audits, audit: audit } }
@@ -211,18 +210,18 @@ RSpec.describe Event, type: :model do
         }
       end
 
-      let(:expected_nomethod_message) do
-        "Error in Event#for_old_audit?: labware barcode=#{labware_without_audits&.barcode}, " \
-          "audit id=#{audit&.id.inspect}. Original error: undefined method 'id' for nil"
-      end
+      # let(:expected_nomethod_message) do
+      #   "Error in Event#for_old_audit?: labware barcode=#{labware_without_audits&.barcode}, " \
+      #     "audit id=#{audit&.id.inspect}. Original error: undefined method 'id' for nil"
+      # end
 
       before do
         # Remove all audits from the labware
         labware_without_audits.audits.destroy_all
       end
 
-      it 'throws a NoMethodError when trying to access the last audit' do
-        expect { event.for_old_audit? }.to raise_error(NoMethodError, expected_nomethod_message)
+      it 'treats it as a new audit' do
+        expect(event.for_old_audit?).to eq(false)
       end
     end
   end

--- a/spec/models/labware_spec.rb
+++ b/spec/models/labware_spec.rb
@@ -171,13 +171,13 @@ RSpec.describe Labware, type: :model do
 
     it 'when a labware has already been created but is scanned into the same location' do
       labware = create(:labware_with_location)
-      labware.create_audit(administrator)
+      labware.create_audit!(administrator)
       expect(labware.audits.count).to eq(1)
       expect(labware.audits.first.action).to eq(AuditAction::CREATE)
 
       location = labware.location
       labware.update(location: location)
-      labware.create_audit(administrator)
+      labware.create_audit!(administrator)
 
       expect(labware.audits.count).to eq(2)
       expect(labware.audits.last.action).to eq(AuditAction::UPDATE)
@@ -188,21 +188,21 @@ RSpec.describe Labware, type: :model do
 
       it 'when it is new labware' do
         labware = create(:labware)
-        audit = labware.create_audit(user)
+        audit = labware.create_audit!(user)
         expect(audit.message).to eq(create_action.display_text)
       end
 
       it 'when it is new labware with a location' do
         labware = create(:labware_with_location)
-        audit = labware.create_audit(user)
+        audit = labware.create_audit!(user)
         expect(audit.message).to eq("#{create_action.display_text} and stored in #{labware.breadcrumbs}")
       end
 
       it 'when it is existing labware with a location' do
         labware = create(:labware_with_location)
-        labware.create_audit(user)
+        labware.create_audit!(user)
         labware.update(location: create(:location_with_parent))
-        audit = labware.create_audit(user)
+        audit = labware.create_audit!(user)
         expect(audit.message).to eq("#{update_action.display_text} and stored in #{labware.breadcrumbs}")
       end
     end

--- a/spec/models/locations/location_spec.rb
+++ b/spec/models/locations/location_spec.rb
@@ -450,19 +450,19 @@ RSpec.describe Location, type: :model do
 
     it 'when the location has no parent' do
       location = create(:location)
-      audit = location.create_audit(user)
+      audit = location.create_audit!(user)
       expect(audit.message).to eq(create_action.display_text)
     end
 
     it 'when it is a new record with a parent' do
-      audit = location.create_audit(user)
+      audit = location.create_audit!(user)
       expect(audit.message).to eq("#{create_action.display_text} and stored in #{location.breadcrumbs}")
     end
 
     it 'when it is an existing record with a parent' do
       location.audits.create(user: user)
       location.update(parent: next_location)
-      audit = location.create_audit(user)
+      audit = location.create_audit!(user)
       expect(audit.message).to eq("#{update_action.display_text} and stored in #{location.breadcrumbs}")
     end
   end

--- a/spec/models/locations/unordered_location_spec.rb
+++ b/spec/models/locations/unordered_location_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe UnorderedLocation, type: :model do
     let!(:location) { create(:unordered_location_with_parent) }
 
     it 'will create the correct message' do
-      audit = location.create_audit(user)
+      audit = location.create_audit!(user)
       expect(audit.message).to eq("#{create_action.display_text} and stored in #{location.breadcrumbs}")
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe User, type: :model do
   it 'can create an audit message' do
     create_action = AuditAction.new(AuditAction::CREATE)
     user = create(:user)
-    audit = user.create_audit(create(:user))
+    audit = user.create_audit!(create(:user))
     expect(audit.message).to eq(create_action.display_text)
   end
 end


### PR DESCRIPTION
Fixes labware scan form to filter out blank rows.
Makes all audit creation attempts throw exceptions if they fail rather than failing silently.