### PR TITLE
Testing Labwhere against MySQL 8.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
          - 3306 # Default port mappings
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3


### PR DESCRIPTION
This pull request reflects changes to mysql image from 8.0 to 8.4 in CI workflow to verify Labwhere is compatible with the MySQL 8.4 upgrade.